### PR TITLE
fix: build without sentry dsn

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -5,6 +5,8 @@ const withBundleAnalyzer = require('@next/bundle-analyzer')({
   enabled: process.env.ANALYZE === 'true',
 });
 
+const hasSentryDsn = process.env.SENTRY_DSN || process.env.NEXT_PUBLIC_SENTRY_DSN;
+
 const moduleExports = withBundleAnalyzer({
   eslint: {
     // Warning: Dangerously allow production builds to successfully complete even if
@@ -56,4 +58,8 @@ const sentryWebpackPluginOptions = {
   silent: false,
 };
 
-module.exports = withSentryConfig(moduleExports, sentryWebpackPluginOptions);
+const nextConfig = hasSentryDsn
+  ? withSentryConfig(moduleExports, sentryWebpackPluginOptions)
+  : moduleExports;
+
+module.exports = nextConfig;


### PR DESCRIPTION
## Description

This PR fixes not being able to run `yarn build` successfully w/out a local sentry dsn. The presence of the dsn was checked in the sentry config files and on init, but overlooked in the `next.config.js`.


