### PR TITLE
fix: display of non-canonical transactions

### DIFF
--- a/src/common/constants.ts
+++ b/src/common/constants.ts
@@ -143,5 +143,6 @@ export const TransactionStatus: Record<string, TxStatus> = {
   PENDING: 'pending',
   SUCCESS_ANCHOR_BLOCK: 'success_anchor_block',
   SUCCESS_MICROBLOCK: 'success_microblock',
+  NON_CANONICAL: 'non_canonical',
   FAILED: 'failed',
 };

--- a/src/common/types/tx.ts
+++ b/src/common/types/tx.ts
@@ -14,7 +14,12 @@ import {
   Transaction,
 } from '@stacks/stacks-blockchain-api-types';
 
-export type TxStatus = 'pending' | 'success_anchor_block' | 'success_microblock' | 'failed';
+export type TxStatus =
+  | 'pending'
+  | 'success_anchor_block'
+  | 'success_microblock'
+  | 'non_canonical'
+  | 'failed';
 
 export type TokenTransferTxs = TokenTransferTransaction | MempoolTokenTransferTransaction;
 export type CoinbaseTxs = CoinbaseTransaction | MempoolCoinbaseTransaction;

--- a/src/common/utils/transactions.ts
+++ b/src/common/utils/transactions.ts
@@ -1,6 +1,5 @@
 import { MempoolTransaction, Transaction } from '@stacks/stacks-blockchain-api-types';
 import { TransactionStatus } from '@common/constants';
-import { TxStatus } from '@common/types/tx';
 
 export function getTransactionStatus(tx: Transaction | MempoolTransaction) {
   if (tx?.tx_status === 'pending') {
@@ -8,8 +7,8 @@ export function getTransactionStatus(tx: Transaction | MempoolTransaction) {
   } else if (tx?.tx_status === 'success' && tx.is_unanchored) {
     return TransactionStatus.SUCCESS_MICROBLOCK;
   } else if (tx?.tx_status === 'success' && !tx.is_unanchored) {
-    if (!tx.microblock_canonical) {
-      return TransactionStatus.FAILED;
+    if (!tx.canonical || !tx.microblock_canonical) {
+      return TransactionStatus.NON_CANONICAL;
     } else {
       return TransactionStatus.SUCCESS_ANCHOR_BLOCK;
     }

--- a/src/components/function-summary/result.tsx
+++ b/src/components/function-summary/result.tsx
@@ -5,7 +5,6 @@ import { Caption, Pre } from '@components/typography';
 import { border } from '@common/utils';
 import { FunctionSummaryClarityValue } from '@components/function-summary/value';
 import { IconAlertTriangle, IconCircleCheck } from '@tabler/icons';
-import { TransactionStatus } from '@common/constants';
 
 interface FunctionSummaryResultProps {
   result: Transaction['tx_result'];
@@ -14,10 +13,7 @@ interface FunctionSummaryResultProps {
 
 export const FunctionSummaryResult = ({ result, txStatus }: FunctionSummaryResultProps) => {
   if (!result) return null;
-  const { type, value } = cvToJSON(hexToCV(result.hex));
-  const isSuccess =
-    txStatus === TransactionStatus.SUCCESS_ANCHOR_BLOCK ||
-    txStatus === TransactionStatus.SUCCESS_MICROBLOCK;
+  const { success, type, value } = cvToJSON(hexToCV(result.hex));
   const hasType = !type?.includes('UnknownType');
 
   if (type?.includes('tuple')) {
@@ -59,12 +55,12 @@ export const FunctionSummaryResult = ({ result, txStatus }: FunctionSummaryResul
     return (
       <Box width="100%">
         <Flex alignItems="center">
-          {isSuccess ? (
+          {success ? (
             <Box mr="tight" color={color('feedback-success')} as={IconCircleCheck} />
           ) : (
             <Box mr="tight" color={color('feedback-error')} as={IconAlertTriangle} />
           )}
-          <Pre>{hasType ? type : isSuccess ? 'Success' : 'Failed'}</Pre>
+          <Pre>{hasType ? type : success ? 'Success' : 'Failed'}</Pre>
         </Flex>
         <Stack mt="extra-loose" spacing="base" width="100%">
           <FunctionSummaryClarityValue

--- a/src/components/status.tsx
+++ b/src/components/status.tsx
@@ -41,6 +41,7 @@ const labelMap = {
   success: 'Confirmed',
   success_anchor_block: 'Confirmed in anchor block',
   success_microblock: 'Included in microblock',
+  non_canonical: 'Non-canonical (orphaned)',
   failed: 'Failed',
 };
 
@@ -49,6 +50,7 @@ const iconMap = {
   success: CheckIcon,
   success_anchor_block: CheckIcon,
   success_microblock: () => <MicroblockIcon fill="white" />,
+  non_canonical: AlertCircleIcon,
   failed: AlertCircleIcon,
 };
 

--- a/src/components/transaction-details.tsx
+++ b/src/components/transaction-details.tsx
@@ -1,11 +1,12 @@
 import * as React from 'react';
+import NextLink from 'next/link';
 
 import { Box, color, Flex, Stack, Text } from '@stacks/ui';
 import { getMemoString, microToStacks } from '@common/utils';
 
 import { Badge } from '@components/badge';
 import { Link } from '@components/typography';
-import NextLink from 'next/link';
+import { TransactionStatus } from '@common/constants';
 import { Rows } from '@components/rows';
 import { Timestamp } from '@components/timestamp';
 import { MempoolTransaction, Transaction } from '@stacks/stacks-blockchain-api-types';
@@ -83,19 +84,23 @@ const transformDataToRowData = (d: Transaction | MempoolTransaction) => {
     copy: d.tx_id,
   };
   const canonical = {
-    condition: d.tx_status !== 'pending' && 'canonical' in d && !d.canonical,
+    condition:
+      (d.tx_status !== TransactionStatus.PENDING && 'canonical' in d && !d.canonical) ||
+      ('microblock_canonical' in d && !d.microblock_canonical),
     label: {
       children: 'Non-canonical',
     },
     children: (
       <Flex alignItems="center">
-        <Box>This transaction is contained in a non-canonical fork of the Stacks chain.</Box>
+        <Box>
+          Transaction has been orphaned by the canonical chain. It is in a non-canonical fork.
+        </Box>
         <IconButton
           ml="tight"
           icon={QuestionMarkCircleOutlineIcon}
           dark
           as="a"
-          href="https://github.com/blockstack/stacks-blockchain/blob/master/sip/sip-001-burn-election.md#committing-to-a-chain-tip"
+          href="https://github.com/stacksgov/sips/blob/main/sips/sip-001/sip-001-burn-election.md#committing-to-a-chain-tip"
           target="_blank"
         />
       </Flex>


### PR DESCRIPTION
## Description

This PR fixes displaying both `canonical: false` and `microblock_canonical: false` transactions with a tx status of `Non-cononical (orphaned)` in the tx header and the changes the `Non-canonical` summary message to, `Transaction has been orphaned by the canonical chain. It is in a non-canonical fork.` This also updates the information icon link to the correct SIP location for more information: https://github.com/stacksgov/sips/blob/main/sips/sip-001/sip-001-burn-election.md#committing-to-a-chain-tip. The result status will now show the execution result correctly.

Issue #569 

![Screen Shot 2021-10-19 at 10 46 23 AM](https://user-images.githubusercontent.com/6493321/137961731-d5db5c4a-ae38-4952-9242-fb2fb8a6e64a.png)

![Screen Shot 2021-10-19 at 10 46 50 AM](https://user-images.githubusercontent.com/6493321/137961787-16939d26-7f91-4936-883c-51afebcd9380.png)

