### PR TITLE
feat: add non-canonical banner

### DIFF
--- a/src/components/transaction-details.tsx
+++ b/src/components/transaction-details.tsx
@@ -93,7 +93,7 @@ const transformDataToRowData = (d: Transaction | MempoolTransaction) => {
     children: (
       <Flex alignItems="center">
         <Box>
-          Transaction has been orphaned by the canonical chain. It is in a non-canonical fork.
+          Transaction is in a non-canonical fork. It has been orphaned by the canonical chain.
         </Box>
         <IconButton
           ml="tight"


### PR DESCRIPTION
## Description

This PR adds a notice banner at top of the transaction page when the tx is in a non-canonical fork.

Issue: #573 

![Screen Shot 2021-10-20 at 1 53 14 PM](https://user-images.githubusercontent.com/6493321/138155671-b5ba1753-96e0-4fae-a4ed-0648595de0eb.png)

Testing use:
/txid/caf14aa6aae66c121e69bd90e37321b8e56b67e4c478de27b6847d8f6f62d8ed?chain=mainnet
