### PR TITLE
fix: add segment write key to build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,6 +65,7 @@ jobs:
           tags: ${{ steps.docker_meta.outputs.tags }}
           labels: ${{ steps.docker_meta.outputs.labels }}
           build-args: |
+            SEGMENT_WRITE_KEY=${{ secrets.SEGMENT_WRITE_KEY }}
             SENTRY_AUTH_TOKEN=${{ secrets.SENTRY_AUTH_TOKEN }}
             SENTRY_DSN=${{ secrets.SENTRY_DSN }}
             SENTRY_LOG_LEVEL=debug

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -52,6 +52,7 @@ jobs:
           tags: ${{ steps.docker_meta.outputs.tags }}
           labels: ${{ steps.docker_meta.outputs.labels }}
           build-args: |
+            SEGMENT_WRITE_KEY=${{ secrets.SEGMENT_WRITE_KEY }}
             SENTRY_AUTH_TOKEN=${{ secrets.SENTRY_AUTH_TOKEN }}
             SENTRY_DSN=${{ secrets.SENTRY_DSN }}
             SENTRY_LOG_LEVEL=debug

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,8 @@
 FROM node:alpine
 
+# Pass these build args in to configure Segment
+ARG SEGMENT_WRITE_KEY
+
 # Pass these build args in to configure Sentry
 ARG SENTRY_AUTH_TOKEN
 ARG SENTRY_DSN
@@ -20,6 +23,7 @@ RUN apk --no-cache add --virtual \
   && yarn \
   && apk del native-deps
 
+ENV SEGMENT_WRITE_KEY=${SEGMENT_WRITE_KEY}
 ENV SENTRY_AUTH_TOKEN=${SENTRY_AUTH_TOKEN}
 ENV SENTRY_DSN=${SENTRY_DSN}
 ENV SENTRY_LOG_LEVEL=${SENTRY_LOG_LEVEL}


### PR DESCRIPTION
This PR add the SEGMENT_WRITE_KEY to the build process to hopefully fix Segment not logging in production.

Issue #571
