### PR TITLE
fix(sentry): lower logging sampling to 5%

### DIFF
--- a/sentry.client.config.js
+++ b/sentry.client.config.js
@@ -9,7 +9,8 @@ function initSentry() {
     // `release` value here - use the environment variable `SENTRY_RELEASE`, so
     // that it will also get attached to your source maps
     // Adjust this value in production, or use tracesSampler for greater control
-    tracesSampleRate: 1.0,
+    tracesSampleRate: 0.05,
+    sampleRate: 0.05,
   });
 }
 


### PR DESCRIPTION
We're already hitting our sentry limit, owing to vast number of errors coming from explorer. This PR sets the sampling rate to 5%