### PR TITLE
feat: add sip 10 decimal support

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "@segment/snippet": "^4.15.3",
     "@sentry/nextjs": "6.13.2",
     "@stacks/auth": "2.0.1-beta.1",
-    "@stacks/blockchain-api-client": "0.63.0",
+    "@stacks/blockchain-api-client": "0.65.0",
     "@stacks/connect": "6.0.0",
     "@stacks/connect-ui": "5.1.5",
     "@stacks/network": "2.0.0-beta.0",

--- a/src/common/api/client.ts
+++ b/src/common/api/client.ts
@@ -12,6 +12,7 @@ import {
   SearchApi,
   RosettaApi,
   MicroblocksApi,
+  TokensApi,
 } from '@stacks/blockchain-api-client';
 import { NextPageContext } from 'next';
 import { getServerSideApiServer } from '@common/api/utils';
@@ -36,6 +37,7 @@ export function apiClients(config: Configuration) {
   const feesApi = new FeesApi(config);
   const searchApi = new SearchApi(config);
   const rosettaApi = new RosettaApi(config);
+  const tokensApi = new TokensApi(config);
 
   return {
     smartContractsApi,
@@ -50,6 +52,7 @@ export function apiClients(config: Configuration) {
     feesApi,
     searchApi,
     rosettaApi,
+    tokensApi,
   };
 }
 
@@ -57,7 +60,7 @@ export function apiClients(config: Configuration) {
 const unanchoredMiddleware: Middleware = {
   pre: (context: RequestContext) => {
     const url = new URL(context.url);
-    url.searchParams.set('unanchored', 'true');
+    if (!url.toString().includes('/v2')) url.searchParams.set('unanchored', 'true');
     return Promise.resolve({
       init: context.init,
       url: url.toString(),

--- a/src/common/constants.ts
+++ b/src/common/constants.ts
@@ -12,6 +12,8 @@ const config = publicRuntimeConfig;
 const getNumber = (query?: string): number | undefined =>
   query && typeof parseInt(query) === 'number' ? parseInt(query) : undefined;
 
+export const STX_DECIMALS = 6;
+
 export const MICROBLOCKS_ENABLED = true;
 
 export const DEFAULT_POLLING_INTERVAL =

--- a/src/common/utils.tsx
+++ b/src/common/utils.tsx
@@ -16,9 +16,10 @@ import relativeTime from 'dayjs/plugin/relativeTime';
 import { ContractCallTxs } from '@common/types/tx';
 import { Text } from '@components/typography';
 import { IconArrowLeft } from '@tabler/icons';
-import { TESTNET_CHAIN_ID } from '@common/constants';
+import { STX_DECIMALS, TESTNET_CHAIN_ID } from '@common/constants';
 import { NetworkMode, NetworkModes } from '@common/types/network';
 import { NextPageContext } from 'next';
+import BigNumber from 'bignumber.js';
 
 dayjs.extend(relativeTime);
 
@@ -368,4 +369,19 @@ export const getContractIdFromTx = (tx?: Transaction | MempoolTransaction) => {
   if (tx.tx_type === 'contract_call') contractId = tx.contract_call.contract_id;
   if (tx.tx_type === 'smart_contract') contractId = tx.smart_contract.contract_id;
   return contractId;
+};
+
+export function initBigNumber(num: string | number | BigNumber) {
+  return BigNumber.isBigNumber(num) ? num : new BigNumber(num);
+}
+
+export const ftDecimals = (value: number | string | BigNumber, decimals: number) => {
+  return initBigNumber(value)
+    .shiftedBy(-decimals)
+    .toNumber()
+    .toLocaleString('en-US', { maximumFractionDigits: decimals });
+};
+
+export const ftUnshiftDecimals = (value: number | string | BigNumber, decimals: number) => {
+  return initBigNumber(value).shiftedBy(decimals).toString(10);
 };

--- a/src/components/balances/principal-token-balances.tsx
+++ b/src/components/balances/principal-token-balances.tsx
@@ -9,13 +9,12 @@ import { HoverableItem } from '@components/hoverable';
 export const NftBalances: React.FC<{ balances: AddressBalanceResponse }> = ({ balances }) =>
   Object.keys(balances.non_fungible_tokens).length ? (
     <>
-      {Object.keys(balances.non_fungible_tokens).map((token, key, arr) => (
+      {Object.keys(balances.non_fungible_tokens).map((key, index, arr) => (
         <TokenAssetListItem
-          token={token}
-          type="non_fungible_tokens"
-          balances={balances}
-          key={key}
-          isLast={key === arr.length - 1}
+          amount={balances.non_fungible_tokens[key].count}
+          key={index}
+          token={key}
+          tokenType="non_fungible_tokens"
         />
       ))}
     </>
@@ -28,13 +27,12 @@ export const NftBalances: React.FC<{ balances: AddressBalanceResponse }> = ({ ba
 export const FtBalances: React.FC<{ balances: AddressBalanceResponse }> = ({ balances }) =>
   Object.keys(balances.fungible_tokens).length ? (
     <>
-      {Object.keys(balances.fungible_tokens).map((token, key, arr) => (
+      {Object.keys(balances.fungible_tokens).map((key, index, arr) => (
         <TokenAssetListItem
-          token={token}
-          type="fungible_tokens"
-          balances={balances}
-          key={key}
-          isLast={key === arr.length - 1}
+          amount={balances.fungible_tokens[key].balance}
+          key={index}
+          token={key}
+          tokenType="fungible_tokens"
         />
       ))}
     </>

--- a/src/store/accounts.ts
+++ b/src/store/accounts.ts
@@ -68,7 +68,7 @@ const accountInfoQueryFn = async (get: Getter, principal: Principal) => {
 
 // @see https://blockstack.github.io/stacks-blockchain-api/#operation/get_account_balance
 const accountBalancesQueryFn = async (get: Getter, principal: Principal) => {
-  const { accountsApi } = get(apiClientsState);
+  const { accountsApi, tokensApi } = get(apiClientsState);
   return (await accountsApi.getAccountBalance({
     principal,
   })) as AddressBalanceResponse;

--- a/yarn.lock
+++ b/yarn.lock
@@ -2292,10 +2292,10 @@
     jsontokens "^3.0.0"
     query-string "^6.13.1"
 
-"@stacks/blockchain-api-client@0.63.0":
-  version "0.63.0"
-  resolved "https://registry.yarnpkg.com/@stacks/blockchain-api-client/-/blockchain-api-client-0.63.0.tgz#3d676fe0182949bcb20fc265e44ebe8fffb5062b"
-  integrity sha512-rdBSzZWL8kXz18NLFPCmd/HwP+mbHAvdkGfTCvtNsj40dSexEYlc93Xz710M843WxNjL1HWgVnrcAjnHH4WlSw==
+"@stacks/blockchain-api-client@0.65.0":
+  version "0.65.0"
+  resolved "https://registry.yarnpkg.com/@stacks/blockchain-api-client/-/blockchain-api-client-0.65.0.tgz#bd972375d4e2e5aa56edfbfb897aef7d29445301"
+  integrity sha512-SaKjSm0P0d/y6IPRJtGAKUxgcsz1WeMDQm7kZu2PZha7f6FqsuWNtWBmiZOnOtEhF7cqyP1MdST3Q0okY85UcQ==
   dependencies:
     "@stacks/stacks-blockchain-api-types" "*"
     "@types/ws" "^7.4.0"


### PR DESCRIPTION
This isn't the most DRY implementation, but bc of how these pages/components are built, this might be the best solution until we can give the explorer more attention and remove query atoms like we have done in the web wallet. The ft/nft tokens really need to be handled separately so that the fetch for data isn't done conditionally (which breaks the rules of hooks, so can't do it). This does resolve issues with missing ft decimals for now.

Issues: #402, #506, and #604

![Screen Shot 2021-12-28 at 12 29 45 PM](https://user-images.githubusercontent.com/6493321/147831871-367db5b9-f645-4f64-8ad3-a3980ac693a1.png)

![Screen Shot 2021-12-28 at 2 44 16 PM](https://user-images.githubusercontent.com/6493321/147831878-50e8e47c-fbbe-4f43-be5f-b3104b5a9a0c.png)

![Screen Shot 2021-12-28 at 3 58 06 PM](https://user-images.githubusercontent.com/6493321/147831881-16f0add1-10c2-4d36-8afc-df6ac7766eb1.png)
