### PR TITLE
fix: View schedule for addresses with unlocking tokens

### DIFF
--- a/src/components/modals.tsx
+++ b/src/components/modals.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import { SearchModal } from '@components/modals/search';
 import { AddNetworkModal } from '@components/modals/add-network';
-import { UnlockingScheduleModal } from '@components/modals/unlocking-schedule';
 import { SafeSuspense } from '@components/ssr-safe-suspense';
 
 export const Modals: React.FC = () => {
@@ -9,7 +8,6 @@ export const Modals: React.FC = () => {
     <>
       <SafeSuspense fallback={<></>}>
         <SearchModal />
-        <UnlockingScheduleModal />
         <AddNetworkModal />
       </SafeSuspense>
     </>

--- a/src/pages/address/[principal].tsx
+++ b/src/pages/address/[principal].tsx
@@ -20,8 +20,8 @@ import { useRefreshOnBack } from '../../hooks/use-refresh-on-back';
 import { AccountTransactionList } from '@features/account-transaction-list';
 import { PageWrapper } from '@components/page-wrapper';
 import { AddressNotFound } from '@components/address-not-found';
-import {UnlockingScheduleModal} from "@components/modals/unlocking-schedule";
-import {SafeSuspense} from "@components/ssr-safe-suspense";
+import { UnlockingScheduleModal } from '@components/modals/unlocking-schedule';
+import { SafeSuspense } from '@components/ssr-safe-suspense';
 
 const PageTop = () => {
   return (

--- a/src/pages/address/[principal].tsx
+++ b/src/pages/address/[principal].tsx
@@ -20,6 +20,8 @@ import { useRefreshOnBack } from '../../hooks/use-refresh-on-back';
 import { AccountTransactionList } from '@features/account-transaction-list';
 import { PageWrapper } from '@components/page-wrapper';
 import { AddressNotFound } from '@components/address-not-found';
+import {UnlockingScheduleModal} from "@components/modals/unlocking-schedule";
+import {SafeSuspense} from "@components/ssr-safe-suspense";
 
 const PageTop = () => {
   return (
@@ -64,6 +66,9 @@ const AddressPage: NextPage<any> = ({ error, principal }) => {
 
   return (
     <PageWrapper>
+      <SafeSuspense fallback={<></>}>
+        <UnlockingScheduleModal />
+      </SafeSuspense>
       <Meta
         title={`STX Address ${truncateMiddle(principal)}`}
         labels={[

--- a/src/pages/txid/[txid].tsx
+++ b/src/pages/txid/[txid].tsx
@@ -14,8 +14,8 @@ import { Meta } from '@components/meta-head';
 import { TxNotFound } from '@components/tx-not-found';
 import { InView } from '@store/currently-in-view';
 import { useChainModeEffect } from '@common/hooks/use-chain-mode';
-import {UnlockingScheduleModal} from "@components/modals/unlocking-schedule";
-import {SafeSuspense} from "@components/ssr-safe-suspense";
+import { UnlockingScheduleModal } from '@components/modals/unlocking-schedule';
+import { SafeSuspense } from '@components/ssr-safe-suspense';
 
 interface TransactionPageProps {
   inView: InView;

--- a/src/pages/txid/[txid].tsx
+++ b/src/pages/txid/[txid].tsx
@@ -14,6 +14,8 @@ import { Meta } from '@components/meta-head';
 import { TxNotFound } from '@components/tx-not-found';
 import { InView } from '@store/currently-in-view';
 import { useChainModeEffect } from '@common/hooks/use-chain-mode';
+import {UnlockingScheduleModal} from "@components/modals/unlocking-schedule";
+import {SafeSuspense} from "@components/ssr-safe-suspense";
 
 interface TransactionPageProps {
   inView: InView;
@@ -33,6 +35,9 @@ const TransactionPage: NextPage<TransactionPageProps> = ({ error, isPossiblyVali
   useRefreshOnBack('txid');
   return (
     <>
+      <SafeSuspense fallback={<></>}>
+        <UnlockingScheduleModal />
+      </SafeSuspense>
       <TransactionMeta />
       <TransactionPageComponent />
     </>


### PR DESCRIPTION
We currently use `withInitialQueries` from `jotai-query-toolkit`, this HOC [wraps the page into a new Jotai provider](https://github.com/fungible-systems/jotai-query-toolkit/blob/3cdba6c65d09c615b1851a2f9c02db3273c60848/src/nextjs/intial-queries-wrapper.ts#L30-L34).
This creates an isolated state for each wrapped page, which prevents it from updating the state outside page scope (in this case, modal state).
A **temporary** fix could be to move this modal to the pages where it's being used. We probably should aim towards eliminating `jotai-query-toolkit` in the near future.
#561