### PR TITLE
feat: add nonce indicator on pending transactions when viewing an address (#622)

### DIFF
--- a/src/components/transaction-item.tsx
+++ b/src/components/transaction-item.tsx
@@ -158,6 +158,17 @@ const Timestamp: React.FC<BoxProps & { tx: Transaction | MempoolTransaction }> =
   }
 );
 
+const Nonce: React.FC<BoxProps & { nonce: Number, isHovered?: boolean }> = React.memo(
+  props => (
+      <>
+        {'·'}
+        <Caption as="span" text-align="right" ml="6px">
+         {props.nonce}
+        </Caption>
+      </>
+    )
+);
+
 const LargeVersion = React.memo(
   ({
     tx,
@@ -205,9 +216,14 @@ const LargeVersion = React.memo(
                 {didFail && 'Failed'}
               </Caption>
               {'·'}
-              <Caption mt="1px" ml="6px">
+              <Caption mt="1px" ml="6px" mr={isPending && "6px"}>
                 {truncateMiddle(tx.tx_id, 4)}
               </Caption>
+
+              { isPending &&
+                <Nonce ml="6px" nonce={tx.nonce} isHovered={isHovered}>
+                </Nonce>
+              }
             </Flex>
           </Stack>
         ) : null}

--- a/src/components/transaction-item.tsx
+++ b/src/components/transaction-item.tsx
@@ -165,7 +165,7 @@ const Nonce: React.FC<BoxProps & { nonce: Number, isHovered?: boolean }> = React
         {'·'}
         <Tooltip label="Nonce">
           <Caption as="span" text-align="right" ml="6px" style={{zIndex:1}}>
-            {props.nonce}
+            {props.nonce + "n"}
           </Caption>
         </Tooltip>
       </>

--- a/src/components/transaction-item.tsx
+++ b/src/components/transaction-item.tsx
@@ -163,7 +163,7 @@ const Nonce: React.FC<BoxProps & { nonce: Number, isHovered?: boolean }> = React
   props => (
       <>
         {'·'}
-        <Tooltip label="nonce">
+        <Tooltip label="Nonce">
           <Caption as="span" text-align="right" ml="6px" style={{zIndex:1}}>
             {props.nonce}
           </Caption>

--- a/src/components/transaction-item.tsx
+++ b/src/components/transaction-item.tsx
@@ -159,7 +159,7 @@ const Timestamp: React.FC<BoxProps & { tx: Transaction | MempoolTransaction }> =
   }
 );
 
-const Nonce: React.FC<BoxProps & { nonce: Number, isHovered?: boolean }> = React.memo(
+const Nonce: React.FC<{ nonce: Number }> = React.memo(
   props => (
       <>
         {'·'}

--- a/src/components/transaction-item.tsx
+++ b/src/components/transaction-item.tsx
@@ -11,6 +11,7 @@ import { Link } from '@components/link';
 import NextLink from 'next/link';
 import { getTxTypeIcon, ItemIcon } from '@components/item-icon';
 import { useHoverableState } from '@components/hoverable';
+import { Tooltip } from '@components/tooltip';
 
 export { getTxTypeIcon };
 
@@ -162,9 +163,11 @@ const Nonce: React.FC<BoxProps & { nonce: Number, isHovered?: boolean }> = React
   props => (
       <>
         {'·'}
-        <Caption as="span" text-align="right" ml="6px">
-         {props.nonce}
-        </Caption>
+        <Tooltip label="nonce">
+          <Caption as="span" text-align="right" ml="6px" style={{zIndex:1}}>
+            {props.nonce}
+          </Caption>
+        </Tooltip>
       </>
     )
 );
@@ -221,7 +224,7 @@ const LargeVersion = React.memo(
               </Caption>
 
               { isPending &&
-                <Nonce ml="6px" nonce={tx.nonce} isHovered={isHovered}>
+                <Nonce ml="6px" nonce={tx.nonce}>
                 </Nonce>
               }
             </Flex>

--- a/src/components/transaction-item.tsx
+++ b/src/components/transaction-item.tsx
@@ -224,8 +224,7 @@ const LargeVersion = React.memo(
               </Caption>
 
               { isPending &&
-                <Nonce ml="6px" nonce={tx.nonce}>
-                </Nonce>
+                <Nonce ml="6px" nonce={tx.nonce}/>
               }
             </Flex>
           </Stack>


### PR DESCRIPTION
Adds a indicator next to pending transactions, reasons detailed here (#622).