### PR TITLE
fix: locale decimal separator issue

### DIFF
--- a/src/common/utils.tsx
+++ b/src/common/utils.tsx
@@ -385,3 +385,7 @@ export const ftDecimals = (value: number | string | BigNumber, decimals: number)
 export const ftUnshiftDecimals = (value: number | string | BigNumber, decimals: number) => {
   return initBigNumber(value).shiftedBy(decimals).toString(10);
 };
+
+export function getLocaleDecimalSeparator() {
+  return (1.1).toLocaleString().substring(1, 2);
+}

--- a/src/common/utils.tsx
+++ b/src/common/utils.tsx
@@ -387,5 +387,5 @@ export const ftUnshiftDecimals = (value: number | string | BigNumber, decimals: 
 };
 
 export function getLocaleDecimalSeparator() {
-  return (1.1).toLocaleString().substring(1, 2);
+  return Intl.NumberFormat().formatToParts(1.1).find(part => part.type === 'decimal')?.value
 }

--- a/src/components/balances/stx-balance-card.tsx
+++ b/src/components/balances/stx-balance-card.tsx
@@ -4,7 +4,7 @@ import { Box, BoxProps, Circle, color, Flex, Grid, Stack, StxInline } from '@sta
 import { Caption, Text } from '@components/typography';
 
 import { Section } from '@components/section';
-import { border, microToStacks } from '@common/utils';
+import { border, microToStacks, getLocaleDecimalSeparator } from '@common/utils';
 import { IconButton } from '@components/icon-button';
 import { IconQrcode, IconX } from '@tabler/icons';
 import { Tooltip } from '@components/tooltip';
@@ -18,13 +18,14 @@ import { useAtomValue } from 'jotai/utils';
 import { accountInViewTokenOfferingData } from '@store/currently-in-view';
 
 export const BalanceItem = ({ balance, ...rest }: any) => {
-  const parts = balance.split('.');
+  const localeDecimalSeparator = getLocaleDecimalSeparator();
+  const parts = balance.split(localeDecimalSeparator);
 
   return (
     <Flex as="span" {...rest} style={{ userSelect: 'all' }}>
       <Text color="currentColor">{parts[0]}</Text>
       <Text color="currentColor" opacity={0.65}>
-        .{parts[1]}
+        {localeDecimalSeparator}{parts[1]}
       </Text>
       <Text ml="extra-tight" color="currentColor">
         STX


### PR DESCRIPTION
Fix for https://github.com/hirosystems/explorer/issues/625
Fix multiple issues at once related to localization.

![decimalgerman](https://user-images.githubusercontent.com/5720927/153018900-fef3a9d5-5382-4507-b1fb-715f2e5975c7.png)

