### PR TITLE
fix: remove microblock txs count

### DIFF
--- a/src/features/blocks-list/hooks.ts
+++ b/src/features/blocks-list/hooks.ts
@@ -1,12 +1,7 @@
-import { useInfiniteQueryAtom, useQueryAtom } from 'jotai-query-toolkit';
+import { useInfiniteQueryAtom } from 'jotai-query-toolkit';
 import { BlocksListResponse, blocksListState } from '@store/blocks';
-import { DEFAULT_BLOCKS_LIST_LIMIT, DEFAULT_LIST_LIMIT_SMALL } from '@common/constants';
-import { microblocksSingleState } from '@store/microblocks';
+import { DEFAULT_BLOCKS_LIST_LIMIT } from '@common/constants';
 import { InfiniteData } from 'react-query';
-
-export function useMicroblock(microblockHash: string) {
-  return useQueryAtom(microblocksSingleState(microblockHash));
-}
 
 export function useBlocksList(limit = DEFAULT_BLOCKS_LIST_LIMIT) {
   return useInfiniteQueryAtom<InfiniteData<BlocksListResponse> | undefined>(blocksListState(limit));

--- a/src/features/blocks-list/microblock-list-item.tsx
+++ b/src/features/blocks-list/microblock-list-item.tsx
@@ -1,12 +1,10 @@
 import React from 'react';
-import pluralize from 'pluralize';
 import { useHoverableState } from '@components/hoverable';
 import { color, Flex, Stack } from '@stacks/ui';
 import { ItemIcon } from '@components/item-icon';
 import { Caption, Text, Title } from '@components/typography';
-import { addSepBetweenStrings, toRelativeTime, truncateMiddle } from '@common/utils';
+import { toRelativeTime, truncateMiddle } from '@common/utils';
 import { MicroblockLink } from '@components/links';
-import { useMicroblock } from './hooks';
 
 export const MicroblockItem: React.FC<{
   blockTime: number;
@@ -15,10 +13,9 @@ export const MicroblockItem: React.FC<{
   length: number;
 }> = ({ blockTime, hash, index, length, ...rest }) => {
   const isHovered = useHoverableState();
-  const [microblock] = useMicroblock(hash);
 
-  return microblock ? (
-    <MicroblockLink hash={microblock.microblock_hash} {...rest}>
+  return (
+    <MicroblockLink hash={hash} {...rest}>
       <Flex
         justifyContent="space-between"
         py="loose"
@@ -34,16 +31,10 @@ export const MicroblockItem: React.FC<{
           <Stack spacing="tight" as="span">
             <Flex color={color(isHovered ? 'brand' : 'text-title')} alignItems="center">
               <Title display="block" color="currentColor">
-                {truncateMiddle(microblock.microblock_hash)}
+                {truncateMiddle(hash)}
               </Title>
             </Flex>
-            <Caption display="block">
-              {'Microblock' +
-                ' · ' +
-                addSepBetweenStrings([
-                  `${microblock.txs.length} ${pluralize('transactions', microblock.txs.length)}`,
-                ])}
-            </Caption>
+            <Caption display="block">Microblock</Caption>
           </Stack>
         </Stack>
         <Stack spacing="tight" textAlign="right" as="span">
@@ -59,5 +50,5 @@ export const MicroblockItem: React.FC<{
         </Stack>
       </Flex>
     </MicroblockLink>
-  ) : null;
+  );
 };


### PR DESCRIPTION
A temporary solution to prevent /blocks page from spamming API. Txs count will be added back once [API support](https://github.com/hirosystems/stacks-blockchain-api/issues/1048) is implemented.
closes: #640 