### PR TITLE
fix: move suspense

### DIFF
--- a/src/components/modals.tsx
+++ b/src/components/modals.tsx
@@ -1,15 +1,12 @@
 import React from 'react';
 import { SearchModal } from '@components/modals/search';
 import { AddNetworkModal } from '@components/modals/add-network';
-import { SafeSuspense } from '@components/ssr-safe-suspense';
 
 export const Modals: React.FC = () => {
   return (
     <>
-      <SafeSuspense fallback={<></>}>
-        <SearchModal />
-        <AddNetworkModal />
-      </SafeSuspense>
+      <SearchModal />
+      <AddNetworkModal />
     </>
   );
 };

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect } from 'react';
 import toast from 'react-hot-toast';
+import { Provider } from 'react-redux';
 import { useRouter } from 'next/router';
 import App from 'next/app';
 import type { AppProps, AppContext } from 'next/app';
@@ -14,7 +15,7 @@ import { getServerSideApiServer } from '@common/api/utils';
 import { NetworkModeToast } from '@components/network-mode-toast';
 import { Modals } from '@components/modals';
 import { store } from '@common/state/store';
-import { Provider } from 'react-redux';
+import { SafeSuspense } from '@components/ssr-safe-suspense';
 
 interface ExplorerAppProps extends AppProps {
   apiServer: string;
@@ -39,9 +40,11 @@ function ExplorerApp({
       <Devtools />
       <AppConfig isHome={isHome} fullWidth={fullWidth}>
         <AtomDebug />
-        <Component apiServer={apiServer} networkMode={networkMode} {...props} />
-        <Modals />
-        <NetworkModeToast />
+        <SafeSuspense fallback={<></>}>
+          <Component apiServer={apiServer} networkMode={networkMode} {...props} />
+          <Modals />
+          <NetworkModeToast />
+        </SafeSuspense>
       </AppConfig>
     </Provider>
   );

--- a/src/pages/address/[principal].tsx
+++ b/src/pages/address/[principal].tsx
@@ -21,7 +21,6 @@ import { AccountTransactionList } from '@features/account-transaction-list';
 import { PageWrapper } from '@components/page-wrapper';
 import { AddressNotFound } from '@components/address-not-found';
 import { UnlockingScheduleModal } from '@components/modals/unlocking-schedule';
-import { SafeSuspense } from '@components/ssr-safe-suspense';
 
 const PageTop = () => {
   return (
@@ -66,9 +65,7 @@ const AddressPage: NextPage<any> = ({ error, principal }) => {
 
   return (
     <PageWrapper>
-      <SafeSuspense fallback={<></>}>
-        <UnlockingScheduleModal />
-      </SafeSuspense>
+      <UnlockingScheduleModal />
       <Meta
         title={`STX Address ${truncateMiddle(principal)}`}
         labels={[

--- a/src/pages/txid/[txid].tsx
+++ b/src/pages/txid/[txid].tsx
@@ -15,7 +15,6 @@ import { TxNotFound } from '@components/tx-not-found';
 import { InView } from '@store/currently-in-view';
 import { useChainModeEffect } from '@common/hooks/use-chain-mode';
 import { UnlockingScheduleModal } from '@components/modals/unlocking-schedule';
-import { SafeSuspense } from '@components/ssr-safe-suspense';
 
 interface TransactionPageProps {
   inView: InView;
@@ -35,9 +34,7 @@ const TransactionPage: NextPage<TransactionPageProps> = ({ error, isPossiblyVali
   useRefreshOnBack('txid');
   return (
     <>
-      <SafeSuspense fallback={<></>}>
-        <UnlockingScheduleModal />
-      </SafeSuspense>
+      <UnlockingScheduleModal />
       <TransactionMeta />
       <TransactionPageComponent />
     </>


### PR DESCRIPTION
The application error in the linked issue is hard to reproduce with a running local env, so debugging is tricky on this. The error is telling us to move the Suspense boundary higher in the component tree. I believe this was (perhaps) introduced with the changes in this PR? https://github.com/hirosystems/explorer/pull/614

@He1DAr any thoughts on this solution to try? I can't say for sure it fixes the error bc I can't reproduce it locally. 

![Screen Shot 2022-03-16 at 9 19 05 AM](https://user-images.githubusercontent.com/6493321/158656528-f3aca841-106b-43b8-8c8c-65a3d9223153.png)
