### PR TITLE
ci: docker image digests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,7 +103,6 @@ jobs:
         with:
           token: ${{ secrets.GH_TOKEN }}
           repository: ${{ secrets.DEVOPS_ACTIONS_REPO }}
-          ref: feat/image-ids
 
       - name: Deploy Explorer
         uses: ./actions/deploy
@@ -147,7 +146,6 @@ jobs:
         with:
           token: ${{ secrets.GH_TOKEN }}
           repository: ${{ secrets.DEVOPS_ACTIONS_REPO }}
-          ref: feat/image-ids
 
       - name: Deploy Explorer
         uses: ./actions/deploy

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,10 +34,11 @@ jobs:
   build-publish:
     runs-on: ubuntu-latest
     outputs:
+      docker_image_id: ${{ steps.docker_push.outputs.imageid }}
       version: ${{ steps.docker_meta.outputs.version }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           token: ${{ secrets.GH_TOKEN || secrets.GITHUB_TOKEN }}
 
@@ -59,6 +60,7 @@ jobs:
           password: ${{ secrets.DOCKERHUB_PASSWORD }}
 
       - name: Build/Tag/Push Image
+        id: docker_push
         uses: docker/build-push-action@v2
         with:
           push: true
@@ -97,10 +99,11 @@ jobs:
       cancel-in-progress: true
     steps:
       - name: Checkout actions repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           token: ${{ secrets.GH_TOKEN }}
           repository: ${{ secrets.DEVOPS_ACTIONS_REPO }}
+          ref: feat/image-ids
 
       - name: Deploy Explorer
         uses: ./actions/deploy
@@ -108,6 +111,7 @@ jobs:
           argocd_apps: ${{ env.DEPLOY_ENV }}.${{ github.event.repository.name }}
           argocd_password: ${{ secrets.ARGOCD_PASSWORD }}
           argocd_username: ${{ secrets.ARGOCD_USERNAME }}
+          docker_tag: ${{ needs.build-publish.outputs.docker_image_id }}
           file_pattern: sites/explorer/${{ env.DEPLOY_ENV }}/deployment.yaml
           gh_token: ${{ secrets.GH_TOKEN }}
 
@@ -139,10 +143,11 @@ jobs:
       cancel-in-progress: true
     steps:
       - name: Checkout actions repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           token: ${{ secrets.GH_TOKEN }}
           repository: ${{ secrets.DEVOPS_ACTIONS_REPO }}
+          ref: feat/image-ids
 
       - name: Deploy Explorer
         uses: ./actions/deploy
@@ -150,5 +155,6 @@ jobs:
           argocd_apps: ${{ env.DEPLOY_ENV }}.${{ github.event.repository.name }}
           argocd_password: ${{ secrets.ARGOCD_PASSWORD }}
           argocd_username: ${{ secrets.ARGOCD_USERNAME }}
+          docker_tag: ${{ needs.build-publish.outputs.docker_image_id }}
           file_pattern: sites/explorer/${{ env.DEPLOY_ENV }}/deployment.yaml
           gh_token: ${{ secrets.GH_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
   build-publish:
     runs-on: ubuntu-latest
     outputs:
-      docker_image_id: ${{ steps.docker_push.outputs.imageid }}
+      docker_image_digest: ${{ steps.docker_push.outputs.digest }}
       version: ${{ steps.docker_meta.outputs.version }}
     steps:
       - name: Checkout
@@ -83,7 +83,7 @@ jobs:
             @semantic-release/git
 
       - name: Deployment Info
-        run: 'echo "::warning::Will deploy docker tag: ${{ steps.docker_meta.outputs.version }}"'
+        run: 'echo "::warning::Will deploy docker tag/digest: ${{ steps.docker_meta.outputs.version }}/${{ steps.docker_push.outputs.digest }}"'
 
   deploy-staging:
     runs-on: ubuntu-latest
@@ -111,7 +111,7 @@ jobs:
           argocd_apps: ${{ env.DEPLOY_ENV }}.${{ github.event.repository.name }}
           argocd_password: ${{ secrets.ARGOCD_PASSWORD }}
           argocd_username: ${{ secrets.ARGOCD_USERNAME }}
-          docker_tag: ${{ needs.build-publish.outputs.docker_image_id }}
+          docker_tag: ${{ needs.build-publish.outputs.docker_image_digest }}
           file_pattern: sites/explorer/${{ env.DEPLOY_ENV }}/deployment.yaml
           gh_token: ${{ secrets.GH_TOKEN }}
 
@@ -155,6 +155,6 @@ jobs:
           argocd_apps: ${{ env.DEPLOY_ENV }}.${{ github.event.repository.name }}
           argocd_password: ${{ secrets.ARGOCD_PASSWORD }}
           argocd_username: ${{ secrets.ARGOCD_USERNAME }}
-          docker_tag: ${{ needs.build-publish.outputs.docker_image_id }}
+          docker_tag: ${{ needs.build-publish.outputs.docker_image_digest }}
           file_pattern: sites/explorer/${{ env.DEPLOY_ENV }}/deployment.yaml
           gh_token: ${{ secrets.GH_TOKEN }}


### PR DESCRIPTION
Leverages a new feature in our deployment action to specify Docker image digests instead of the general tag on CI deployments.
This helps resolve the scenario where two commits are pushed to a branch, and the first commit gets deployed, but the second one results in a no-op deployment since the tag didn't change.

Resolves https://github.com/hirosystems/devops/issues/927

[Working](https://github.com/hirosystems/explorer/actions/runs/2204240909)