### PR TITLE
ci: use github ref if tag is not passed to deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -24,7 +24,7 @@ jobs:
     steps:
       - name: Checkout
         if: github.event.inputs.tag == ''
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           token: ${{ secrets.GH_TOKEN || secrets.GITHUB_TOKEN }}
 
@@ -74,7 +74,7 @@ jobs:
       cancel-in-progress: true
     steps:
       - name: Checkout actions repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           token: ${{ secrets.GH_TOKEN }}
           repository: ${{ secrets.DEVOPS_ACTIONS_REPO }}
@@ -87,7 +87,7 @@ jobs:
           argocd_username: ${{ secrets.ARGOCD_USERNAME }}
           file_pattern: sites/explorer/${{ env.DEPLOY_ENV }}/deployment.yaml
           gh_token: ${{ secrets.GH_TOKEN }}
-          docker_tag: ${{ github.event.inputs.tag }}
+          docker_tag: ${{ github.event.inputs.tag || github.ref }}
 
   auto-approve-staging:
     runs-on: ubuntu-latest
@@ -115,7 +115,7 @@ jobs:
       cancel-in-progress: true
     steps:
       - name: Checkout actions repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           token: ${{ secrets.GH_TOKEN }}
           repository: ${{ secrets.DEVOPS_ACTIONS_REPO }}
@@ -128,4 +128,4 @@ jobs:
           argocd_username: ${{ secrets.ARGOCD_USERNAME }}
           file_pattern: sites/explorer/${{ env.DEPLOY_ENV }}/deployment.yaml
           gh_token: ${{ secrets.GH_TOKEN }}
-          docker_tag: ${{ github.event.inputs.tag }}
+          docker_tag: ${{ github.event.inputs.tag || github.ref }}


### PR DESCRIPTION
Uses the Github commit reference if no tag is passed to the deploy workflow. Tags should now deploy without getting re-built, while build + deploying branches is now functional again.
Confirmed working [1](https://github.com/hirosystems/explorer/runs/6133934158?check_suite_focus=true) & [2](https://github.com/hirosystems/explorer/runs/6134041549?check_suite_focus=true)

Closes https://github.com/hirosystems/devops/issues/930
