### PR TITLE
ci: only allow tag deployments to prod

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -102,6 +102,7 @@ jobs:
           fi
 
   deploy-prod:
+    if: github.event.inputs.tag != '' # Only deploy tags to prod
     runs-on: ubuntu-latest
     needs:
       - deploy-staging


### PR DESCRIPTION
Prevent anything but tags from being deployed to production.