### PR TITLE
feat: skip prefetch for devnet

### DIFF
--- a/src/common/api/client.ts
+++ b/src/common/api/client.ts
@@ -14,11 +14,10 @@ import {
   MicroblocksApi,
   TokensApi,
 } from '@stacks/blockchain-api-client';
-import { NextPageContext } from 'next';
 import { fetcher as fetchApi } from '@common/api/fetch';
 import type { Middleware, RequestContext } from '@stacks/blockchain-api-client';
 import { MICROBLOCKS_ENABLED } from '@common/constants';
-import { selectActiveNetwork } from '@common/state/network-slice';
+import { selectActiveNetwork, selectActiveNetworkUrl } from '@common/state/network-slice';
 import { useAppSelector } from '@common/state/hooks';
 import { store } from '@common/state/store';
 
@@ -72,7 +71,7 @@ const unanchoredMiddleware: Middleware = {
 };
 
 // we use to to create our api client config on both the server and client
-export function createConfig(basePath: string) {
+export function createConfig(basePath?: string) {
   const middleware: Middleware[] = [];
   if (MICROBLOCKS_ENABLED) middleware.push(unanchoredMiddleware);
   return new Configuration({
@@ -85,7 +84,7 @@ export function createConfig(basePath: string) {
 // this is used in next.js specific data fetchers, typically only by getApiClients
 // this will pass the correct network url as defined by cookie (or default value)
 export const getApiClientConfig = (): Configuration => {
-  const apiServer = store.getState().network.activeNetworkKey;
+  const apiServer = selectActiveNetworkUrl(store.getState());
   return createConfig(apiServer);
 };
 // this is used in next.js specific data fetchers to get all our api clients fetching from the correct network url

--- a/src/common/state/network-slice.ts
+++ b/src/common/state/network-slice.ts
@@ -1,5 +1,5 @@
 import { createSelector, createSlice, PayloadAction } from '@reduxjs/toolkit';
-import { DEFAULT_MAINNET_SERVER } from '@common/constants';
+import { DEFAULT_MAINNET_SERVER, IS_BROWSER } from '@common/constants';
 import { RootState } from '@common/state/store';
 import { HYDRATE } from 'next-redux-wrapper';
 import { DEFAULT_NETWORK_MAP } from '@common/constants/network';
@@ -65,3 +65,14 @@ export const selectActiveNetwork = createSelector(
   [selectNetworkSlice, selectNetworks],
   (networkSlice, networks) => networks[networkSlice.activeNetworkKey]
 );
+
+export const selectActiveNetworkUrl = createSelector([selectActiveNetwork], activeNetwork => {
+  if (
+    activeNetwork &&
+    !IS_BROWSER &&
+    ['localhost', '127.0.0.1'].includes(new URL(activeNetwork.url).hostname)
+  ) {
+    return undefined;
+  }
+  return activeNetwork?.url;
+});

--- a/src/components/meta/transactions.tsx
+++ b/src/components/meta/transactions.tsx
@@ -103,9 +103,7 @@ export const TransactionMeta = () => {
   const { query } = useRouter();
   const txId = query.txid as string;
   const { data } = useQuery(['transaction', txId], queries.fetchTransaction(txId));
-  const transaction = data?.transaction;
-
-  if (!transaction) return null;
+  const transaction = data?.transaction || ({} as Transaction);
 
   const txStatus = useMemo(() => getTransactionStatus(transaction), [transaction]);
   const pageTitle = `${getTxPageTitle(transaction)}${
@@ -126,6 +124,8 @@ export const TransactionMeta = () => {
           },
         ]
       : undefined;
+
+  if (!transaction) return null;
 
   return (
     <Meta

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -12,13 +12,14 @@ import { AppConfig } from '@components/app-config';
 import { NetworkMode } from '@common/types/network';
 import { NetworkModeToast } from '@components/network-mode-toast';
 import { Modals } from '@components/modals';
-import { wrapper } from '@common/state/store';
+import { store, wrapper } from '@common/state/store';
 import { QueryClient, QueryClientProvider } from 'react-query';
 import { Hydrate } from 'react-query/hydration';
 import { EnhancedStore } from '@reduxjs/toolkit';
 import { ParsedUrlQuery } from 'querystring';
 import {
   selectActiveNetwork,
+  selectActiveNetworkUrl,
   selectNetworks,
   selectNetworkSlice,
   setActiveNetwork,
@@ -73,9 +74,9 @@ function ExplorerApp({ Component, ...rest }: ExplorerAppProps): React.ReactEleme
 const handleNetworkModeQueryParam = (store: EnhancedStore, appContext: AppContext) => {
   if (appContext.ctx.pathname === '/_error') return;
   const query = appContext.ctx.query;
-  const activeNetwork = selectActiveNetwork(store.getState() as never);
-  const networks = selectNetworks(store.getState() as never);
-  console.log('[debug] activeNetworkKey', store.getState().network.activeNetworkKey);
+  const activeNetwork = selectActiveNetwork(store.getState());
+  const networks = selectNetworks(store.getState());
+  console.log('[debug] selectActiveNetworkUrl', selectActiveNetworkUrl(store.getState()));
   console.log('[debug] activeNetwork', activeNetwork);
   console.log('[debug] networks', networks);
   const queryNetworkMode = (Array.isArray(query.chain) ? query.chain[0] : query.chain) || '';

--- a/src/store/accounts.ts
+++ b/src/store/accounts.ts
@@ -57,15 +57,6 @@ export const getAccountQueryKey = {
 // queryFn's
 // ----------------
 
-// @see https://blockstack.github.io/stacks-blockchain-api/#operation/get_account_info
-const accountInfoQueryFn = async (get: Getter, principal: Principal) => {
-  const { accountsApi } = get(apiClientsState);
-  return accountsApi.getAccountInfo({
-    principal,
-    proof: 0, // no need to fetch the proof
-  });
-};
-
 // @see https://blockstack.github.io/stacks-blockchain-api/#operation/get_account_balance
 const accountBalancesQueryFn = async (get: Getter, principal: Principal) => {
   const { accountsApi, tokensApi } = get(apiClientsState);
@@ -179,10 +170,6 @@ const accountInboundQueryFn = async (
 // ----------------
 // atoms
 // ----------------
-export const accountInfoState = atomFamilyWithQuery<string, AccountDataResponse>(
-  AccountsQueryKeys.INFO,
-  accountInfoQueryFn
-);
 export const accountBalancesResponseState = atomFamilyWithQuery<string, AddressBalanceResponse>(
   AccountsQueryKeys.BALANCES,
   accountBalancesQueryFn

--- a/src/store/api-clients.ts
+++ b/src/store/api-clients.ts
@@ -3,11 +3,11 @@ import { Configuration } from '@stacks/blockchain-api-client';
 import { DEFAULT_MAINNET_SERVER } from '@common/constants';
 import { apiClients, createConfig } from '@common/api/client';
 import { store } from '@common/state/store';
+import { selectActiveNetworkUrl } from '@common/state/network-slice';
 
 export const apiClientConfiguration = atom<Configuration>(() => {
-  const networkUrl = store.getState().network.activeNetworkKey;
-  const apiServer = networkUrl || DEFAULT_MAINNET_SERVER;
-  return createConfig(apiServer);
+  const networkUrl = selectActiveNetworkUrl(store.getState());
+  return createConfig(networkUrl);
 });
 
 export const apiClientsState = atom(get => {

--- a/src/store/currently-in-view.ts
+++ b/src/store/currently-in-view.ts
@@ -12,7 +12,6 @@ import type {
 } from '@stacks/stacks-blockchain-api-types';
 import {
   accountBalancesResponseState,
-  accountInfoState,
   accountPendingTransactionsState,
   accountStxBalanceResponseState,
   accountTransactionsState,


### PR DESCRIPTION
Exploring a fix to devnet (localhost) server-side data fetching. Basically skipping prefetch, which will cause the client to do the requests instead of the server.