### PR TITLE
Fix error where contract call page renders with more hooks

### DIFF
--- a/src/components/tx/contract-call.tsx
+++ b/src/components/tx/contract-call.tsx
@@ -30,9 +30,8 @@ const ContractCallPage: React.FC<{
     transactionQK(TransactionQueryKeys.contract, contractId),
     queries.fetchContract(contractId)
   );
-  if (!contract) return null;
 
-  const source = contract.source_code;
+  const source = contract?.source_code;
   const btc = null;
   const txStatus = useMemo(() => getTransactionStatus(transaction), [transaction]);
   const isPending = txStatus === TransactionStatus.PENDING;


### PR DESCRIPTION
I haven't got a repro for this on Testnet, but I have a transaction locally that with the current code has an error when I click its transaction page:

"instrument.js:109 Error: Minified React error #310; visit https://reactjs.org/docs/error-decoder.html?invariant=310 for the full message or use the non-minified dev environment for full errors and additional helpful warnings." 

The react doc says that message is "Rendered more hooks than during the previous render."

When I pulled the repo locally I can see it's caused by the `const txStatus = useMemo(() => getTransactionStatus(transaction), [transaction]);` in `src/components/tx/contract-call.tsx`

From debugging/testing locally, it's the `if (!contract) return null;` which is causing the issue. On a subsequent render `contract` is set, and so we skip the early return, hit `useMemo`, and run more hooks than when we returned previously.

The fix I've used is to remove this early return, and update the `source` on the next line to handle the case where `contract` is not set.

Since `contract` is typed as `any`, it's not immediately clear whether I've changed the type of `source` from `string` to `string | undefined`. But the uses of `source` on the page appear to already handle it being undefined: there's `!!source` and it's also passed in to `ContractSource` who's `source` parameter is already typed as `string | undefined`. So if I have changed the type of `source` then I believe it is already handled correctly.

This fixes the issue for me locally, and doesn't cause any issues I can see on any other transaction. 