### PR TITLE
fix: display 0 instead of blank in address summary

### DIFF
--- a/src/features/address-page/address-summary.tsx
+++ b/src/features/address-page/address-summary.tsx
@@ -49,7 +49,7 @@ export const AddressSummary = ({
             label: {
               children: 'Nonce',
             },
-            children: nonce,
+            children: `${nonce}`,
           },
         ]}
       />


### PR DESCRIPTION
closes #606