### PR TITLE
feat: fetch and display status

### DIFF
--- a/src/components/header.tsx
+++ b/src/components/header.tsx
@@ -10,6 +10,7 @@ import { MobileMenu } from '@components/mobile-menu';
 import { NetworkModeBanner } from '@components/network-mode-banner';
 import { useAppDispatch } from '@common/state/hooks';
 import { buildUrl } from '@components/links';
+import { StatusBar } from '@features/status-bar/status-bar';
 
 const ColorModeButton = dynamic(() => import('@components/color-mode-button'), { ssr: false });
 
@@ -76,6 +77,7 @@ export const Header: React.FC<
   const dispatch = useAppDispatch();
   return (
     <>
+      <StatusBar />
       <HeaderBar
         mx="auto"
         width="100%"

--- a/src/features/status-bar/status-bar.tsx
+++ b/src/features/status-bar/status-bar.tsx
@@ -1,0 +1,83 @@
+import { Box, Text } from '@stacks/ui';
+import { css } from '@emotion/react';
+import { useEffect, useState } from 'react';
+import { BsExclamationCircle, BsExclamationTriangle } from 'react-icons/bs';
+import { Link } from 'components/link';
+
+enum Indicator {
+  none = 'none',
+  minor = 'minor',
+  major = 'major',
+  critical = 'critical',
+}
+interface StatusProps {
+  description: string;
+  indicator: Indicator;
+}
+
+const backgroundStyle = css`
+  width: 100%;
+  background: rgba(255, 255, 255, 0.8);
+  z-index: 2;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 20px 0;
+`;
+
+const wrapperStyle = css`
+  width: 100%;
+  max-width: 1280px;
+  padding: 0 32px;
+`;
+
+const iconStyle = css`
+  margin-right: 9px;
+  position: relative;
+  top: 2px;
+`;
+
+export const StatusBar: React.FC = () => {
+  const [status, setStatus] = useState<StatusProps>({
+    description: '',
+    indicator: Indicator.none,
+  });
+  useEffect(() => {
+    void fetch('https://status.hiro.so/api/v2/status.json')
+      .then(res => res.json())
+      .then(data => setStatus(data.status));
+  }, []);
+  const { indicator, description } = status;
+  if (indicator === Indicator.none) return null;
+  const color = indicator === Indicator.critical ? '#C83532' : '#A96500';
+  const icon =
+    indicator === Indicator.critical ? (
+      <BsExclamationCircle color={color} css={iconStyle} />
+    ) : (
+      <BsExclamationTriangle color={color} css={iconStyle} />
+    );
+  return (
+    <Box css={backgroundStyle}>
+      <Box css={wrapperStyle}>
+        {icon}
+        <Text color={color} fontWeight={500} fontSize={'14px'} lineHeight={'21px'}>
+          {description}
+          {description.endsWith('.') ? '' : '.'}
+        </Text>{' '}
+        <Text fontWeight={400} fontSize={'14px'}>
+          More information on the{' '}
+          <Link
+            href="https://status.hiro.so/"
+            target="_blank"
+            css={css`
+              display: inline;
+            `}
+          >
+            Hiro status page
+          </Link>
+          .
+        </Text>
+      </Box>
+    </Box>
+  );
+};


### PR DESCRIPTION
Fetch and display status with a link to the status page `https://status.hiro.so/`

![unknown](https://user-images.githubusercontent.com/97111756/182501743-8698fd63-aa6d-40a6-986d-02892ea5a12b.png)
![unknown](https://user-images.githubusercontent.com/97111756/182501752-a6b63cfc-42e7-4a33-a838-aa74625bdede.png)
![unknown](https://user-images.githubusercontent.com/97111756/182501757-a6affbb2-f3a5-4698-86a6-91d05dfe171c.png)

closes #780 