### PR TITLE
feat: BTC and STX block height links

### DIFF
--- a/src/components/btc-stx-block-links.tsx
+++ b/src/components/btc-stx-block-links.tsx
@@ -1,0 +1,106 @@
+import { FC, Fragment } from 'react';
+import { FaBitcoin } from 'react-icons/fa';
+import { BsArrowRightShort } from 'react-icons/bs';
+import { Box, Text, color } from '@stacks/ui';
+import { css } from '@emotion/react';
+import { IconArrowRight } from '@tabler/icons';
+import { buildUrl } from '@components/links';
+import { useRouter } from 'next/router';
+import { StxInline } from '@components/icons/stx-inline';
+import { Circle } from '@components/circle';
+import { useAppSelector } from '@common/state/hooks';
+import { selectActiveNetwork } from '@common/state/network-slice';
+
+interface BtcStxBlockLinksProps {
+  btcBlockHeight?: number;
+  stxBlockHeight: number;
+  stxBlockHash: string;
+  fontSize?: string;
+}
+
+const wrapperStyle = css`
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+`;
+
+const iconStyle = css`
+  margin-right: 3px;
+`;
+
+const linkStyle = (secondary?: boolean, clickable?: boolean, fontSize?: string) => css`
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  font-weight: 500;
+  font-family: 'Open Sauce', Inter, sans-serif;
+  ${fontSize ? `font-size: ${fontSize};` : 'font-size: 14px;'}
+  ${clickable &&
+  `
+    cursor: pointer;
+    &:hover {
+      text-decoration: underline;
+    }
+  `}
+  ${secondary &&
+  `
+    color: #747478;
+    font-size: 12px;
+  `}
+`;
+
+const arrowStyle = css`
+  margin: 0 8px;
+`;
+
+export const BtcStxBlockLinks: FC<BtcStxBlockLinksProps> = ({
+  btcBlockHeight,
+  stxBlockHeight,
+  stxBlockHash,
+  fontSize,
+}) => {
+  const router = useRouter();
+  const activeNetworkUrl = useAppSelector(selectActiveNetwork).url;
+
+  return (
+    <Box css={wrapperStyle}>
+      <Circle size="19px" bg={color('accent')} css={iconStyle}>
+        <StxInline strokeWidth={2} size="11px" color="white" />
+      </Circle>
+      <Box
+        css={linkStyle(false, stxBlockHash !== '', fontSize)}
+        onClick={e => {
+          if (stxBlockHash !== '') {
+            e.preventDefault();
+            void router.push(
+              buildUrl(`/block/${encodeURIComponent(stxBlockHash)}`, activeNetworkUrl)
+            );
+          }
+        }}
+      >
+        #{stxBlockHeight}
+      </Box>
+      {btcBlockHeight && (
+        <Fragment>
+          <IconArrowRight size="14px" color={'#747478'} css={arrowStyle} />
+          <FaBitcoin color={'#f7931a'} size={19} css={iconStyle} />
+          <Box
+            css={linkStyle(true, true, fontSize)}
+            onClick={e => {
+              e.preventDefault();
+              window
+                ?.open(
+                  `https://www.blockchain.com/btc/block/${btcBlockHeight}`,
+                  '_blank',
+                  'noopener'
+                )
+                ?.focus();
+            }}
+          >
+            #{btcBlockHeight}
+          </Box>
+        </Fragment>
+      )}
+    </Box>
+  );
+};

--- a/src/components/tx/coinbase.tsx
+++ b/src/components/tx/coinbase.tsx
@@ -21,7 +21,7 @@ const CoinbasePage: React.FC<{
       <PageTop tx={transaction} />
       <PagePanes fullWidth={transaction.tx_status === 'pending' || !block}>
         <Box>
-          <TransactionDetails transaction={transaction} />
+          <TransactionDetails transaction={transaction} block={block} />
           {'events' in transaction && (
             <Events txId={transaction.tx_id} mt="extra-loose" events={transaction.events} />
           )}

--- a/src/components/tx/contract-call.tsx
+++ b/src/components/tx/contract-call.tsx
@@ -47,7 +47,7 @@ const ContractCallPage: React.FC<{
         }
       >
         <Stack spacing="extra-loose">
-          <TransactionDetails transaction={transaction} />
+          <TransactionDetails transaction={transaction} block={block} />
           {'events' in transaction && transaction.events && (
             <Events txId={transaction.tx_id} events={transaction.events} />
           )}

--- a/src/components/tx/poison-microblock.tsx
+++ b/src/components/tx/poison-microblock.tsx
@@ -7,11 +7,14 @@ import { PoisonMicroblockTxs, TxData } from '@common/types/tx';
 import { Block } from '@stacks/stacks-blockchain-api-types';
 
 // TODO: make this real
-const PoisonMicroblockPage = ({ transaction }: TxData<PoisonMicroblockTxs> & { block?: Block }) => (
+const PoisonMicroblockPage = ({
+  transaction,
+  block,
+}: TxData<PoisonMicroblockTxs> & { block?: Block }) => (
   <>
     <PageTop tx={transaction as any} />
     <Stack spacing="extra-loose">
-      <TransactionDetails transaction={transaction} hideContract />
+      <TransactionDetails transaction={transaction} block={block} hideContract />
       <Rows
         items={[
           {

--- a/src/components/tx/smart-contract.tsx
+++ b/src/components/tx/smart-contract.tsx
@@ -46,6 +46,7 @@ const SmartContractPage: React.FC<{
           <TransactionDetails
             contractName={getContractName(transaction.smart_contract.contract_id)}
             transaction={transaction}
+            block={block}
           />
           {'events' in transaction && (
             <Events txId={transaction.tx_id} events={transaction.events} />

--- a/src/components/tx/token-transfer.tsx
+++ b/src/components/tx/token-transfer.tsx
@@ -21,7 +21,7 @@ const TokenTransferPage: React.FC<{
       <PageTop tx={transaction as any} />
       <PagePanes fullWidth={transaction.tx_status === 'pending' || block === null}>
         <Stack spacing="extra-loose">
-          <TransactionDetails transaction={transaction} hideContract />
+          <TransactionDetails transaction={transaction} block={block} hideContract />
           {'events' in transaction && (
             <Events txId={transaction.tx_id} events={transaction.events} />
           )}

--- a/src/features/blocks-list/block-list-item.tsx
+++ b/src/features/blocks-list/block-list-item.tsx
@@ -8,6 +8,7 @@ import HashtagIcon from 'mdi-react/HashtagIcon';
 import { Caption, Text, Title } from '@components/typography';
 import { addSepBetweenStrings, toRelativeTime, truncateMiddle } from '@common/utils';
 import pluralize from 'pluralize';
+import { BtcStxBlockLinks } from '@components/btc-stx-block-links';
 
 export const BlockItem: React.FC<{ block: Block; index: number; length: number }> = React.memo(
   ({ block, index, length, ...rest }) => {
@@ -28,10 +29,12 @@ export const BlockItem: React.FC<{ block: Block; index: number; length: number }
             <ItemIcon size="40px" type="block" />
             <Stack spacing="tight" as="span">
               <Flex color={color(isHovered ? 'brand' : 'text-title')} alignItems="center">
-                <Box size="16px" as={HashtagIcon} mr="1px" opacity={0.5} color="currentColor" />
-                <Title display="block" color="currentColor">
-                  {String(block.height)}
-                </Title>
+                <BtcStxBlockLinks
+                  btcBlockHeight={block.burn_block_height}
+                  stxBlockHeight={block.height}
+                  stxBlockHash={block.hash}
+                  fontSize={'16px'}
+                />
               </Flex>
               <Caption display="block">
                 {'Anchor block' +

--- a/src/pages/block/[hash].tsx
+++ b/src/pages/block/[hash].tsx
@@ -26,6 +26,7 @@ import { ServerResponse } from 'http';
 import { useRouter } from 'next/router';
 import { QueryClient, useQuery } from 'react-query';
 import { dehydrate } from 'react-query/hydration';
+import { BtcStxBlockLinks } from '@components/btc-stx-block-links';
 
 interface BlockSinglePageData {
   hash: string;
@@ -95,7 +96,13 @@ const BlockSinglePage: NextPage<BlockSinglePageData> = ({ error }) => {
                   label: {
                     children: 'Block height',
                   },
-                  children: `#${block.height}`,
+                  children: (
+                    <BtcStxBlockLinks
+                      btcBlockHeight={block.burn_block_height}
+                      stxBlockHeight={block.height}
+                      stxBlockHash={block.hash}
+                    />
+                  ),
                 },
                 {
                   label: {


### PR DESCRIPTION
Create a new component `<BtcStxBlockLinks />` to render both STX and BTC block height with links in all places where we want to show block details.
![image](https://user-images.githubusercontent.com/97111756/183515392-c9b30c2e-74af-4971-a7f6-7478ed9d70c3.png)
<img width="1230" alt="image" src="https://user-images.githubusercontent.com/97111756/183515442-275c7fbe-337a-4f4c-adf3-307b8cbb572f.png">
<img width="1231" alt="image" src="https://user-images.githubusercontent.com/97111756/183515508-1a4a3e66-fea4-4ae9-9fc8-2fe0559b6892.png">
