### PR TITLE
fix: add tabs in home page skeleton

### DIFF
--- a/src/modules/TransactionList/components/TxsListWithTabs.tsx
+++ b/src/modules/TransactionList/components/TxsListWithTabs.tsx
@@ -61,5 +61,9 @@ export const TxsListWithTabs: React.FC<{
       </Wrapper>
     );
 
-  return <SkeletonGenericTransactionList />;
+  return (
+    <Wrapper>
+      <SkeletonGenericTransactionList />
+    </Wrapper>
+  );
 });


### PR DESCRIPTION
This adds back the tabs header (Confirmed, Pending) for the skeleton on the home page transaction list
cc: @He1DAr 

Before:
<img width="1260" alt="b1" src="https://user-images.githubusercontent.com/1501454/186148671-e79c9718-3456-4fd2-a100-60294c3f0143.png">


After:

<img width="1366" alt="b2" src="https://user-images.githubusercontent.com/1501454/186149018-cff9ded5-203a-4268-aedf-65a12624f04b.png">

