### PR TITLE
feat: add a link to the blockchain.com explorer from the bitcoin block height on the block page

### DIFF
--- a/src/components/btc-anchor-card.tsx
+++ b/src/components/btc-anchor-card.tsx
@@ -23,7 +23,15 @@ export const BtcAnchorBlockCard: React.FC<FlexProps & { block: Block }> = ({ blo
               label: {
                 children: 'Bitcoin block height',
               },
-              children: `#${block.burn_block_height}`,
+              children: (
+                <Link
+                  as="a"
+                  target="_blank"
+                  href={`https://www.blockchain.com/btc/block/${block.burn_block_height}`}
+                >
+                  #{block.burn_block_height}
+                </Link>
+              ),
             },
             {
               label: {
@@ -36,7 +44,7 @@ export const BtcAnchorBlockCard: React.FC<FlexProps & { block: Block }> = ({ blo
                   href={`https://www.blockchain.com/btc${path}/block/${block.burn_block_hash.replace(
                     '0x',
                     ''
-                  )}?utm_source=stacks_explorer`}
+                  )}`}
                 >
                   {truncateMiddle(block.burn_block_hash, 8)}
                 </Link>
@@ -54,7 +62,7 @@ export const BtcAnchorBlockCard: React.FC<FlexProps & { block: Block }> = ({ blo
                   href={`https://www.blockchain.com/btc${path}/tx/${block.miner_txid.replace(
                     '0x',
                     ''
-                  )}?utm_source=stacks_explorer`}
+                  )}`}
                 >
                   {truncateMiddle(block.miner_txid, 8)}
                 </Link>


### PR DESCRIPTION
Closes https://github.com/hirosystems/explorer/issues/826

Within the "Bitcoin anchor" section on the right side of the block page, the "Bitcoin block height" text will have a link to the blockchain.com explorer.

<img width="347" alt="Screen Shot 2022-08-31 at 4 26 13 PM" src="https://user-images.githubusercontent.com/2423414/187996087-60b4ca4c-8844-4ef3-81e1-baa381e3de9b.png">
