### PR TITLE
feat: change all external btc links to mempool.space

### DIFF
--- a/src/components/btc-anchor-card.tsx
+++ b/src/components/btc-anchor-card.tsx
@@ -11,7 +11,8 @@ import { selectActiveNetwork } from '@common/state/network-slice';
 
 export const BtcAnchorBlockCard: React.FC<FlexProps & { block: Block }> = ({ block, ...rest }) => {
   const networkMode = useAppSelector(selectActiveNetwork).mode;
-  const path = networkMode === NetworkModes.Testnet ? '-testnet' : '';
+  const btcLinkPathPrefix = networkMode === NetworkModes.Testnet ? '/testnet' : '';
+
   return (
     <Section title="Bitcoin anchor" {...rest}>
       <Box px="base">
@@ -27,7 +28,7 @@ export const BtcAnchorBlockCard: React.FC<FlexProps & { block: Block }> = ({ blo
                 <Link
                   as="a"
                   target="_blank"
-                  href={`https://www.blockchain.com/btc/block/${block.burn_block_height}`}
+                  href={`https://mempool.space${btcLinkPathPrefix}/block/${block.burn_block_height}`}
                 >
                   #{block.burn_block_height}
                 </Link>
@@ -41,7 +42,7 @@ export const BtcAnchorBlockCard: React.FC<FlexProps & { block: Block }> = ({ blo
                 <Link
                   as="a"
                   target="_blank"
-                  href={`https://www.blockchain.com/btc${path}/block/${block.burn_block_hash.replace(
+                  href={`https://mempool.space${btcLinkPathPrefix}/block/${block.burn_block_hash.replace(
                     '0x',
                     ''
                   )}`}
@@ -59,7 +60,7 @@ export const BtcAnchorBlockCard: React.FC<FlexProps & { block: Block }> = ({ blo
                 <Link
                   as="a"
                   target="_blank"
-                  href={`https://www.blockchain.com/btc${path}/tx/${block.miner_txid.replace(
+                  href={`https://mempool.space${btcLinkPathPrefix}/tx/${block.miner_txid.replace(
                     '0x',
                     ''
                   )}`}

--- a/src/components/btc-stx-block-links.tsx
+++ b/src/components/btc-stx-block-links.tsx
@@ -10,6 +10,7 @@ import { StxInline } from '@components/icons/stx-inline';
 import { Circle } from '@components/circle';
 import { useAppSelector } from '@common/state/hooks';
 import { selectActiveNetwork } from '@common/state/network-slice';
+import { NetworkModes } from '@common/types/network';
 
 interface BtcStxBlockLinksProps {
   btcBlockHeight?: number;
@@ -61,6 +62,7 @@ export const BtcStxBlockLinks: FC<BtcStxBlockLinksProps> = ({
 }) => {
   const router = useRouter();
   const activeNetworkMode = useAppSelector(selectActiveNetwork).mode;
+  const btcLinkPathPrefix = activeNetworkMode === NetworkModes.Testnet ? '/testnet' : '';
 
   return (
     <Box css={wrapperStyle}>
@@ -90,7 +92,7 @@ export const BtcStxBlockLinks: FC<BtcStxBlockLinksProps> = ({
               e.preventDefault();
               window
                 ?.open(
-                  `https://www.blockchain.com/btc/block/${btcBlockHeight}`,
+                  `https://mempool.space${btcLinkPathPrefix}/block/${btcBlockHeight}`,
                   '_blank',
                   'noopener'
                 )

--- a/src/components/function-summary/value.tsx
+++ b/src/components/function-summary/value.tsx
@@ -7,6 +7,7 @@ import { TxLink } from '@components/links';
 import { useAppSelector } from '@common/state/hooks';
 import { selectActiveNetwork } from '@common/state/network-slice';
 import { cvToJSON, hexToCV } from '@stacks/transactions';
+import { NetworkModes } from '@common/types/network';
 
 const getPrettyClarityValueType = (type: any) => {
   if (type === 'bool' || type === 'int' || type === 'principal' || type === 'uint') {
@@ -37,6 +38,7 @@ const tupleToArr = (tuple: string) =>
 
 const TupleResult = ({ tuple, isPoxAddr, btc }: any) => {
   const networkMode = useAppSelector(selectActiveNetwork).mode;
+  const btcLinkPathPrefix = networkMode === NetworkModes.Testnet ? '/testnet' : '';
   let additional: any = null;
   if (isPoxAddr && btc) {
     additional = (
@@ -45,9 +47,7 @@ const TupleResult = ({ tuple, isPoxAddr, btc }: any) => {
         <Text
           target="_blank"
           as={Link}
-          href={`https://www.blockchain.com/btc${
-            networkMode === 'testnet' ? '-testnet' : ''
-          }/address/${btc}`}
+          href={`https://mempool.space${btcLinkPathPrefix}/address/${btc}`}
         >
           {btc}
         </Text>

--- a/src/features/blocks-visualizer/index.tsx
+++ b/src/features/blocks-visualizer/index.tsx
@@ -13,6 +13,7 @@ import { buildUrl } from '@components/links';
 import { useAppSelector } from '@common/state/hooks';
 import { selectActiveNetwork } from '@common/state/network-slice';
 import { TransactionQueryKeys } from '@features/transaction/query-keys';
+import { NetworkModes } from '@common/types/network';
 
 const wrapperStyle = css`
   display: flex;
@@ -195,6 +196,8 @@ const Block: React.FC<BlockProps> = ({
   const timeBetweenBlocksFormatted = secondsToString(timeBetweenBlocks);
   const router = useRouter();
   const activeNetworkMode = useAppSelector(selectActiveNetwork).mode;
+  const btcLinkPathPrefix = activeNetworkMode === NetworkModes.Testnet ? '/testnet' : '';
+
   return (
     <Box css={blockWrapperStyle}>
       <Box css={blockAndArrowStyle}>
@@ -208,7 +211,7 @@ const Block: React.FC<BlockProps> = ({
           css={blockStyle}
           onClick={() => {
             window
-              ?.open(`https://www.blockchain.com/btc/block/${btcBlockHeight}`, '_blank')
+              ?.open(`https://mempool.space${btcLinkPathPrefix}/block/${btcBlockHeight}`, '_blank')
               ?.focus();
           }}
         >


### PR DESCRIPTION
Closes #533 

Link to mempool.space rather than blockchain.com for all external btc links. Also ensures path is prefixed appropriately for mempool.space links while using testnet