### PR TITLE
feat: show usd values alongside balances on address page

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,4 @@
+#!/bin/sh
+. "$(dirname "$0")/_/husky.sh"
+
+yarn lint:prettier

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   "author": "Hiro Systems PBC (formerly Blockstack PBC)",
   "dependencies": {
     "@babel/core": "7.14.8",
+    "@emotion/babel-preset-css-prop": "11.2.0",
     "@emotion/cache": "11.4.0",
     "@emotion/core": "11.0.0",
     "@emotion/css": "11.1.3",
@@ -96,8 +97,7 @@
     "valid-url": "1.0.9",
     "web-api-hooks": "3.0.2",
     "webpack": "5.47.0",
-    "yup": "0.32.9",
-    "@emotion/babel-preset-css-prop": "11.2.0"
+    "yup": "0.32.9"
   },
   "devDependencies": {
     "@commitlint/config-conventional": "12.1.4",

--- a/src/common/hooks/use-current-prices.ts
+++ b/src/common/hooks/use-current-prices.ts
@@ -1,0 +1,15 @@
+import { useQuery } from 'react-query';
+
+const getCurrentBtcPrice = async () =>
+  fetch('https://api.coingecko.com/api/v3/exchange_rates')
+    .then(res => res.json())
+    .then(data => data?.rates?.usd?.value);
+
+export const useCurrentBtcPrice = () => useQuery('current-btc-price', getCurrentBtcPrice);
+
+const getCurrentStxPrice = async () =>
+  fetch('https://api.coingecko.com/api/v3/simple/price?ids=blockstack,bitcoin&vs_currencies=usd')
+    .then(res => res.json())
+    .then(data => data?.blockstack?.usd);
+
+export const useCurrentStxPrice = () => useQuery('current-stx-price', getCurrentStxPrice);

--- a/src/components/btc-stx-price.tsx
+++ b/src/components/btc-stx-price.tsx
@@ -4,6 +4,7 @@ import { Box, color } from '@stacks/ui';
 import { css } from '@emotion/react';
 import { StxInline } from '@components/icons/stx-inline';
 import { Circle } from '@components/circle';
+import { useCurrentBtcPrice, useCurrentStxPrice } from '@common/hooks/use-current-prices';
 
 const wrapperStyle = css`
   display: flex;
@@ -32,36 +33,25 @@ const formatter = new Intl.NumberFormat('en-US', {
 });
 
 export const BtcStxPrice: FC = () => {
-  const [stxPrice, setStxPrice] = useState<string | undefined>();
-  const [btcPrice, setBtcPrice] = useState<string | undefined>();
-  useEffect(() => {
-    void fetch('https://api.coingecko.com/api/v3/exchange_rates')
-      .then(res => res.json())
-      .then(data => {
-        setBtcPrice(formatter.format(data.rates.usd.value));
-      });
-    void fetch(
-      'https://api.coingecko.com/api/v3/simple/price?ids=blockstack,bitcoin&vs_currencies=usd'
-    )
-      .then(res => res.json())
-      .then(data => {
-        setStxPrice(formatter.format(data.blockstack.usd));
-      });
-  }, []);
-  if (!stxPrice || !btcPrice) return null;
+  const { data: btcPrice } = useCurrentBtcPrice();
+  const { data: stxPrice } = useCurrentStxPrice();
+  const formattedBtcPrice = formatter.format(btcPrice);
+  const formattedStxPrice = formatter.format(stxPrice);
+
+  if (!formattedStxPrice || !formattedBtcPrice) return null;
   return (
     <Fragment>
       <Box css={wrapperStyle}>
         <Circle size="18px" bg={'#fff'} css={iconStyle}>
           <FaBitcoin color={'#f7931a'} size={19} />
         </Circle>
-        <Box css={priceStyle}>{btcPrice}</Box>
+        <Box css={priceStyle}>{formattedBtcPrice}</Box>
       </Box>
       <Box css={wrapperStyle}>
         <Circle size="19px" bg={color('accent')} css={iconStyle}>
           <StxInline strokeWidth={2} size="11px" color="white" />
         </Circle>
-        <Box css={priceStyle}>{stxPrice}</Box>
+        <Box css={priceStyle}>{formattedStxPrice}</Box>
       </Box>
     </Fragment>
   );


### PR DESCRIPTION
Closes #853 

Shows USD price alongside all balances on the address page.

<img width="365" alt="Screen Shot 2022-09-07 at 5 40 15 PM" src="https://user-images.githubusercontent.com/2423414/189002390-4fd90f21-406e-4ac6-afad-141476701e68.png">

<img width="360" alt="Screen Shot 2022-09-07 at 5 39 30 PM" src="https://user-images.githubusercontent.com/2423414/189002386-c9c5353f-6843-4757-bd00-e4fc5e3111a0.png">
