### PR TITLE
feat: show usd values alongside amount and fees on transaction page

### DIFF
--- a/src/common/utils.tsx
+++ b/src/common/utils.tsx
@@ -173,6 +173,13 @@ export const handleTxIdValidation = (query?: string): { success: boolean; messag
   }
 };
 
+export const formatStacksAmount = (amountInStacks: number): string => {
+  return amountInStacks.toLocaleString(undefined, {
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 6,
+  });
+};
+
 /**
  * microToStacks
  *
@@ -185,9 +192,26 @@ export const microToStacks = (
 ): number | string => {
   const value = Number(Number(amountInMicroStacks) / Math.pow(10, 6));
   if (localString) {
-    return value.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 6 });
+    return formatStacksAmount(value);
   }
   return value;
+};
+
+/**
+ * @param stxAmount - the amount of stacks (or microstacks) to convert to a USD price
+ * @param currentStxPrice - the current USD price of STX
+ * @param isInMicroStacks - if true, the stxAmount is in microstacks
+ *
+ * @returns string - the formatted current USD price of the given STX
+ */
+export const getUsdValue = (
+  stxAmount: number,
+  currentStxPrice: number,
+  isInMicroStacks: boolean = false
+): string => {
+  const amountInStx = isInMicroStacks ? (microToStacks(stxAmount, false) as number) : stxAmount;
+  const price = amountInStx * currentStxPrice;
+  return price < 0.01 ? '<$0.01' : usdFormatter.format(price);
 };
 
 /**
@@ -412,3 +436,8 @@ export function getContractId(
     ? transaction.contract_call.contract_id
     : undefined;
 }
+
+export const usdFormatter = new Intl.NumberFormat('en-US', {
+  style: 'currency',
+  currency: 'USD',
+});

--- a/src/components/balances/stx-balance-card.tsx
+++ b/src/components/balances/stx-balance-card.tsx
@@ -4,7 +4,14 @@ import { Box, BoxProps, Circle, color, Flex, Grid, Stack, StxInline } from '@sta
 import { Caption, Text } from '@components/typography';
 
 import { Section } from '@components/section';
-import { border, microToStacks, getLocaleDecimalSeparator } from '@common/utils';
+import {
+  border,
+  microToStacks,
+  getLocaleDecimalSeparator,
+  formatStacksAmount,
+  usdFormatter,
+  getUsdValue,
+} from '@common/utils';
 import { IconButton } from '@components/icon-button';
 import { IconQrcode, IconX } from '@tabler/icons';
 import { Tooltip } from '@components/tooltip';
@@ -20,20 +27,12 @@ import { MODALS } from '@common/constants';
 import { useAppDispatch } from '@common/state/hooks';
 import { useCurrentStxPrice } from '@common/hooks/use-current-prices';
 
-const usdFormatter = new Intl.NumberFormat('en-US', {
-  style: 'currency',
-  currency: 'USD',
-});
-
 export const BalanceItem = ({ balance, ...rest }: any) => {
   const { data: stxPrice } = useCurrentStxPrice();
 
-  const formattedBalance = balance.toLocaleString(undefined, {
-    minimumFractionDigits: 2,
-    maximumFractionDigits: 6,
-  });
-  const usdBalance = usdFormatter.format(balance * stxPrice);
-  const localeDecimalSeparator = getLocaleDecimalSeparator();
+  const formattedBalance = formatStacksAmount(balance);
+  const usdBalance = getUsdValue(balance, stxPrice);
+  const localeDecimalSeparator = getLocaleDecimalSeparator() || '.';
   const parts = formattedBalance.split(localeDecimalSeparator);
 
   return (

--- a/src/components/btc-stx-price.tsx
+++ b/src/components/btc-stx-price.tsx
@@ -5,6 +5,7 @@ import { css } from '@emotion/react';
 import { StxInline } from '@components/icons/stx-inline';
 import { Circle } from '@components/circle';
 import { useCurrentBtcPrice, useCurrentStxPrice } from '@common/hooks/use-current-prices';
+import { usdFormatter } from '@common/utils';
 
 const wrapperStyle = css`
   display: flex;
@@ -27,16 +28,11 @@ const priceStyle = css`
   font-size: 14px;
 `;
 
-const formatter = new Intl.NumberFormat('en-US', {
-  style: 'currency',
-  currency: 'USD',
-});
-
 export const BtcStxPrice: FC = () => {
   const { data: btcPrice } = useCurrentBtcPrice();
   const { data: stxPrice } = useCurrentStxPrice();
-  const formattedBtcPrice = formatter.format(btcPrice);
-  const formattedStxPrice = formatter.format(stxPrice);
+  const formattedBtcPrice = usdFormatter.format(btcPrice);
+  const formattedStxPrice = usdFormatter.format(stxPrice);
 
   if (!formattedStxPrice || !formattedBtcPrice) return null;
   return (


### PR DESCRIPTION
Closes #852 

Displays USD values alongside the amount & fee on the Transaction page.

<img width="765" alt="Screen Shot 2022-09-08 at 3 25 26 PM" src="https://user-images.githubusercontent.com/2423414/189228960-d5048d46-93c6-4fe8-971a-53d983676271.png">
