### PR TITLE
feat: show usd values within transaction lists

### DIFF
--- a/src/common/utils.tsx
+++ b/src/common/utils.tsx
@@ -1,5 +1,5 @@
 /** @jsxRuntime classic */
-import { Box, color, ColorsStringLiteral, Stack } from '@stacks/ui';
+import { Box, color, ColorsStringLiteral, Flex, Stack } from '@stacks/ui';
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore
 import { BorderStyleProperty } from 'csstype';
@@ -23,6 +23,7 @@ import { NextPageContext } from 'next';
 import BigNumber from 'bignumber.js';
 import { useQuery } from 'react-query';
 import blocks from '@pages/blocks';
+import React from 'react';
 
 dayjs.extend(relativeTime);
 
@@ -335,7 +336,10 @@ const ContractName = ({ fn, contract }: any) => {
   );
 };
 
-export const getTxTitle = (transaction: Transaction | MempoolTransaction) => {
+export const getTxTitle = (
+  transaction: Transaction | MempoolTransaction,
+  currentStxPrice?: number
+) => {
   switch (transaction.tx_type) {
     case 'smart_contract':
       return getContractName(transaction?.smart_contract?.contract_id);
@@ -347,7 +351,19 @@ export const getTxTitle = (transaction: Transaction | MempoolTransaction) => {
         />
       );
     case 'token_transfer':
-      return `${microToStacks(transaction.token_transfer.amount)} STX`;
+      return (
+        <Flex
+          flexDirection={['column', 'column', 'row']}
+          alignItems={['flex-start', 'flex-start', 'center']}
+        >
+          <Text>{microToStacks(transaction.token_transfer.amount)} STX</Text>
+          {currentStxPrice && (
+            <Text ml={['none', 'none', 'base']} fontSize="14px" color="ink.400">
+              {getUsdValue(Number(transaction.token_transfer.amount), currentStxPrice, true)}
+            </Text>
+          )}
+        </Flex>
+      );
     case 'coinbase':
       return `Block #${(transaction as Transaction).block_height} coinbase`;
     default:

--- a/src/components/transaction-details.tsx
+++ b/src/components/transaction-details.tsx
@@ -30,10 +30,15 @@ interface FeeComponentProps {
 
 const FeesComponent = React.memo(({ fees, sponsored, currentStxPrice }: FeeComponentProps) => (
   <>
-    <Stack spacing="extra-tight">
+    <Flex
+      flexDirection={['column', 'column', 'row']}
+      alignItems={['flex-start', 'flex-start', 'center']}
+    >
       <Text>{microToStacks(fees)} STX</Text>
-      <Text color="ink.400">{getUsdValue(Number(fees), currentStxPrice, true)}</Text>
-    </Stack>
+      <Text color="ink.400" ml={['none', 'none', 'base']}>
+        {getUsdValue(Number(fees), currentStxPrice, true)}
+      </Text>
+    </Flex>
     {sponsored ? (
       <Badge ml="base" bg="ink.300">
         Sponsored
@@ -210,24 +215,28 @@ const transformDataToRowData = (
       const amount = {
         label: 'Amount',
         children: (
-          <Stack alignItems="flex-start" isInline spacing="tight">
-            <Box width="24px" position="relative" mt="base-tight">
-              <Circle position="absolute" left={0} size="24px" bg={color('accent')}>
-                <StxInline strokeWidth={2} size="14px" color="white" />
-              </Circle>
-            </Box>
-            <Stack ml="tight" spacing="extra-tight">
+          <Flex
+            flexDirection={['column', 'column', 'row']}
+            alignItems={['flex-start', 'flex-start', 'center']}
+          >
+            <Stack alignItems="flex-start" isInline spacing="tight">
+              <Box width="24px" position="relative">
+                <Circle position="absolute" left={0} size="24px" bg={color('accent')}>
+                  <StxInline strokeWidth={2} size="14px" color="white" />
+                </Circle>
+              </Box>
+
               <Text fontSize="16px" color={color('text-title')} fontWeight="500">
                 {microToStacks(d.token_transfer.amount)}{' '}
                 <Text as="span" display="inline" opacity="0.5">
                   STX
                 </Text>
               </Text>
-              <Text fontSize="14px" color="ink.400">
-                {getUsdValue(Number(d.token_transfer.amount), currentStxPrice, true)}
-              </Text>
             </Stack>
-          </Stack>
+            <Text fontSize="14px" color="ink.400" ml={['extra-loose', 'extra-loose', 'base']}>
+              {getUsdValue(Number(d.token_transfer.amount), currentStxPrice, true)}
+            </Text>
+          </Flex>
         ),
       };
       const tokenTransferSender = {

--- a/src/components/transaction-item.tsx
+++ b/src/components/transaction-item.tsx
@@ -12,6 +12,7 @@ import { buildUrl } from '@components/links';
 import { getTransactionTypeLabel } from '@components/token-transfer/utils';
 import { Tooltip } from '@components/tooltip';
 import NextLink from 'next/link';
+import { useCurrentStxPrice } from '@common/hooks/use-current-prices';
 
 export { getTxTypeIcon };
 
@@ -186,7 +187,8 @@ const LargeVersion = React.memo(
     isHovered?: boolean;
     hideRightElements?: boolean;
   }) => {
-    const title = getTxTitle(tx);
+    const { data: currentStxPrice } = useCurrentStxPrice();
+    const title = getTxTitle(tx, currentStxPrice);
 
     const isPending = tx.tx_status === 'pending';
     const isConfirmed = tx.tx_status === 'success';

--- a/src/modules/TransactionList/components/MempoolTxsListItem.tsx
+++ b/src/modules/TransactionList/components/MempoolTxsListItem.tsx
@@ -11,6 +11,7 @@ import { AddressArea, Nonce, Timestamp } from '@components/transaction-item';
 import { buildUrl } from '@components/links';
 import { useAppSelector } from '@common/state/hooks';
 import { selectActiveNetwork } from '@common/state/network-slice';
+import { useCurrentStxPrice } from '@common/hooks/use-current-prices';
 
 interface MempoolTxsListItemProps {
   tx: MempoolTransaction;
@@ -20,13 +21,14 @@ export const MempoolTxsListItem: FC<MempoolTxsListItemProps> = memo(({ tx }) => 
   const isPending = tx.tx_status === 'pending';
   const didFail = !isPending;
   const activeNetworkMode = useAppSelector(selectActiveNetwork).mode;
+  const { data: currentStxPrice } = useCurrentStxPrice();
 
   const icon = useMemo(() => <ItemIcon type={'tx'} tx={tx} />, [tx]);
 
   const leftTitle = useMemo(
     () => (
       <Title fontWeight="500" display="block" fontSize="16px">
-        {getTxTitle(tx)}
+        {getTxTitle(tx, currentStxPrice)}
       </Title>
     ),
     []

--- a/src/modules/TransactionList/components/TxsListItem.tsx
+++ b/src/modules/TransactionList/components/TxsListItem.tsx
@@ -12,6 +12,7 @@ import { buildUrl } from '@components/links';
 import { useAppSelector } from '@common/state/hooks';
 import { selectActiveNetwork } from '@common/state/network-slice';
 import { AddressTransactionWithTransfersStxTransfers } from '@stacks/blockchain-api-client/src/generated/models';
+import { useCurrentStxPrice } from '@common/hooks/use-current-prices';
 
 interface TxsListItemProps {
   tx: Transaction;
@@ -22,13 +23,14 @@ export const TxsListItem: FC<TxsListItemProps> = memo(({ tx }) => {
   const isAnchored = !tx.is_unanchored;
   const didFail = !isConfirmed;
   const activeNetworkMode = useAppSelector(selectActiveNetwork).mode;
+  const { data: currentStxPrice } = useCurrentStxPrice();
 
   const icon = useMemo(() => <ItemIcon type={'tx'} tx={tx} />, [tx]);
 
   const leftTitle = useMemo(
     () => (
       <Title fontWeight="500" display="block" fontSize="16px">
-        {getTxTitle(tx)}
+        {getTxTitle(tx, currentStxPrice)}
       </Title>
     ),
     [tx]


### PR DESCRIPTION
Show USD values within transaction lists.

<img width="1354" alt="Screen Shot 2022-09-09 at 12 33 38 PM" src="https://user-images.githubusercontent.com/2423414/189421934-ab555cef-6e16-413a-beee-a8bf6fd79425.png">

On narrow screens, the USD value will stack:

<img width="512" alt="Screen Shot 2022-09-09 at 12 34 26 PM" src="https://user-images.githubusercontent.com/2423414/189421943-bd558ccc-063a-4e09-a240-3b70e555b1aa.png">
