### PR TITLE
chore: remove precommit formatting check, allow devs to configure their own

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,0 @@
-#!/bin/sh
-. "$(dirname "$0")/_/husky.sh"
-
-yarn lint:prettier


### PR DESCRIPTION
Removing precommit formatting check because it's slow and devs can configure their own. re: https://github.com/hirosystems/explorer/pull/855#discussion_r966660812