### PR TITLE
ci: fix ENV var propagation in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,20 +1,10 @@
-# Set Global ARGs
-# Pass these build args in to configure Segment
-ARG SEGMENT_WRITE_KEY
+FROM node:16-alpine AS build
 
-# Pass these build args in to configure Sentry
+ARG SEGMENT_WRITE_KEY
 ARG SENTRY_AUTH_TOKEN
 ARG SENTRY_DSN
 ARG SENTRY_LOG_LEVEL=warn
 ARG NODE_ENV=production
-
-FROM node:16-alpine AS build
-
-ENV SEGMENT_WRITE_KEY=${SEGMENT_WRITE_KEY}
-ENV SENTRY_AUTH_TOKEN=${SENTRY_AUTH_TOKEN}
-ENV SENTRY_DSN=${SENTRY_DSN}
-ENV SENTRY_LOG_LEVEL=${SENTRY_LOG_LEVEL}
-ENV NODE_ENV=production
 
 WORKDIR /app
 
@@ -39,11 +29,18 @@ RUN yarn cache clean
 
 FROM node:16-alpine
 
+ARG SEGMENT_WRITE_KEY
+ARG SENTRY_AUTH_TOKEN
+ARG SENTRY_DSN
+ARG SENTRY_LOG_LEVEL=warn
+ARG NODE_ENV=production
+
+# Set ENVs so they persist after image is built
 ENV SEGMENT_WRITE_KEY=${SEGMENT_WRITE_KEY}
 ENV SENTRY_AUTH_TOKEN=${SENTRY_AUTH_TOKEN}
 ENV SENTRY_DSN=${SENTRY_DSN}
 ENV SENTRY_LOG_LEVEL=${SENTRY_LOG_LEVEL}
-ENV NODE_ENV=production
+ENV NODE_ENV=${NODE_ENV}
 
 RUN apk --no-cache add --virtual \
   yarn

--- a/src/components/app-config.tsx
+++ b/src/components/app-config.tsx
@@ -24,11 +24,11 @@ export const AppConfig: React.FC<AppConfigProps> = ({
   const { events } = useRouter();
 
   useEffect(() => {
-    console.log('mount')
+    console.log('mount');
     if (!window.analytics) return;
-    console.log('analytics')
+    console.log('analytics');
     events.on('routeChangeComplete', (url: string) => {
-      console.log('routeChangeComplete')
+      console.log('routeChangeComplete');
       return window.analytics?.page(url);
     });
   }, []);

--- a/src/pages/_document.tsx
+++ b/src/pages/_document.tsx
@@ -43,14 +43,14 @@ export default class MyDocument extends Document<DocumentProps> {
       // in app-config.js if needed later.
       page: true,
     };
-    console.log('opts', opts)
+    console.log('opts', opts);
     // Use if needed for dev mode
     // if (NODE_ENV !== 'production') return snippet.max(opts);
     return snippet.min(opts);
   }
 
   render() {
-    console.log('SEGMENT_WRITE_KEY', SEGMENT_WRITE_KEY)
+    console.log('SEGMENT_WRITE_KEY', SEGMENT_WRITE_KEY);
     return (
       <Html lang="en">
         <Head>


### PR DESCRIPTION
* Moves the ARGs directives out of the global scope and instead sets it in each dockerfile stage. The workaround to keeping these ARGs global while having them set correctly and persist in each stage is arguably more difficult to maintain and more confusing than this configuration. If it were a longer dockerfile with more stages, it may be warranted.
* Removes the ENVs from the first stage since they only need to be persisted to the image in the last stage, and are still made available during build-time in the first stage through the ARGs.