### PR TITLE
fix: align load more events

### DIFF
--- a/src/components/tx-events.tsx
+++ b/src/components/tx-events.tsx
@@ -376,7 +376,9 @@ export const Events = ({
             Loading...
           </Flex>
         ) : actions.hasNextPage ? (
-          <Caption color="currentColor">Load more events</Caption>
+          <Flex alignItems="center" justifyContent="center">
+            <Caption color="currentColor">Load more events</Caption>
+          </Flex>
         ) : null}
       </Box>
     </Section>


### PR DESCRIPTION
There is an issue with the 'load more events' alignment
<img width="1031" alt="align" src="https://user-images.githubusercontent.com/1501454/195312313-ba7b6fe1-8a64-4e0b-a96b-983f7465eec8.png">
