### PR TITLE
fix: view all blocks and view all transactions incorrect redirect

### DIFF
--- a/src/components/section-footer-button.tsx
+++ b/src/components/section-footer-button.tsx
@@ -6,6 +6,7 @@ import { Caption } from '@components/typography';
 
 import { border } from '@common/utils';
 import { Pending } from '@components/status';
+import { buildUrl } from './links';
 
 interface SectionFooterButtonPropsBase {
   isLoading?: boolean;
@@ -47,7 +48,7 @@ export const SectionFooterAction: React.FC<SectionFooterButtonPropsBase> = ({
       </Grid>
     ) : null
   ) : (
-    <NextLink href={`/${path}`} passHref>
+    <NextLink href={buildUrl(`/${path}`)} passHref>
       <Grid
         as="a"
         borderTop={border()}


### PR DESCRIPTION
To reproduce

1. Open Explorer, select Network -> Testnet
2. Under “Recent Blocks”, click “View all blocks”
3. Observe that the /blocks page is now showing Mainnet blocks instead of testnet

Same issue with "View all transactions"