### PR TITLE
ci: update github token used for most steps to default token

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,14 +38,12 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-        with:
-          token: ${{ secrets.GH_TOKEN || secrets.GITHUB_TOKEN }}
 
       - name: Semantic Release
         uses: cycjimmy/semantic-release-action@v2
         id: semantic
         env:
-          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SEMANTIC_RELEASE_PACKAGE: ${{ github.event.repository.name }}
         with:
           extra_plugins: |
@@ -56,7 +54,6 @@ jobs:
         if: steps.semantic.outputs.new_release_version != ''
         uses: actions/checkout@v3
         with:
-          token: ${{ secrets.GH_TOKEN || secrets.GITHUB_TOKEN }}
           ref: v${{ steps.semantic.outputs.new_release_version }}
 
       - name: Docker meta
@@ -109,7 +106,6 @@ jobs:
       - name: Checkout actions repo
         uses: actions/checkout@v3
         with:
-          token: ${{ secrets.GH_TOKEN }}
           repository: ${{ secrets.DEVOPS_ACTIONS_REPO }}
 
       - name: Deploy Explorer
@@ -130,9 +126,9 @@ jobs:
     steps:
       - name: Approve pending deployment
         run: |
-          ENV_ID=$(curl -s -H "Authorization: token ${{ secrets.GH_TOKEN }}" -H "Accept: application/vnd.github.v3+json" "https://api.github.com/repos/hirosystems/explorer/actions/runs/${{ github.run_id }}/pending_deployments" | jq -r '.[0].environment.id // empty')
+          ENV_ID=$(curl -s -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" -H "Accept: application/vnd.github.v3+json" "https://api.github.com/repos/hirosystems/explorer/actions/runs/${{ github.run_id }}/pending_deployments" | jq -r '.[0].environment.id // empty')
           if [[ -n "${ENV_ID}" ]]; then
-            curl -s -X POST -H "Authorization: token ${{ secrets.GH_TOKEN }}" -H "Accept: application/vnd.github.v3+json" "https://api.github.com/repos/hirosystems/explorer/actions/runs/${{ github.run_id }}/pending_deployments" -d "{\"environment_ids\":[${ENV_ID}],\"state\":\"approved\",\"comment\":\"auto approve\"}"
+            curl -s -X POST -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" -H "Accept: application/vnd.github.v3+json" "https://api.github.com/repos/hirosystems/explorer/actions/runs/${{ github.run_id }}/pending_deployments" -d "{\"environment_ids\":[${ENV_ID}],\"state\":\"approved\",\"comment\":\"auto approve\"}"
           fi
 
   deploy-prod:
@@ -153,7 +149,6 @@ jobs:
       - name: Checkout actions repo
         uses: actions/checkout@v3
         with:
-          token: ${{ secrets.GH_TOKEN }}
           repository: ${{ secrets.DEVOPS_ACTIONS_REPO }}
 
       - name: Deploy Explorer

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,6 +106,7 @@ jobs:
       - name: Checkout actions repo
         uses: actions/checkout@v3
         with:
+          token: ${{ secrets.GH_TOKEN }}
           repository: ${{ secrets.DEVOPS_ACTIONS_REPO }}
 
       - name: Deploy Explorer
@@ -149,6 +150,7 @@ jobs:
       - name: Checkout actions repo
         uses: actions/checkout@v3
         with:
+          token: ${{ secrets.GH_TOKEN }}
           repository: ${{ secrets.DEVOPS_ACTIONS_REPO }}
 
       - name: Deploy Explorer

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -75,6 +75,7 @@ jobs:
       - name: Checkout actions repo
         uses: actions/checkout@v3
         with:
+          token: ${{ secrets.GH_TOKEN }}
           repository: ${{ secrets.DEVOPS_ACTIONS_REPO }}
 
       - name: Deploy Explorer
@@ -116,6 +117,7 @@ jobs:
       - name: Checkout actions repo
         uses: actions/checkout@v3
         with:
+          token: ${{ secrets.GH_TOKEN }}
           repository: ${{ secrets.DEVOPS_ACTIONS_REPO }}
 
       - name: Deploy Explorer

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -25,8 +25,6 @@ jobs:
       - name: Checkout
         if: github.event.inputs.tag == ''
         uses: actions/checkout@v3
-        with:
-          token: ${{ secrets.GH_TOKEN || secrets.GITHUB_TOKEN }}
 
       - name: Docker meta
         if: github.event.inputs.tag == ''
@@ -77,7 +75,6 @@ jobs:
       - name: Checkout actions repo
         uses: actions/checkout@v3
         with:
-          token: ${{ secrets.GH_TOKEN }}
           repository: ${{ secrets.DEVOPS_ACTIONS_REPO }}
 
       - name: Deploy Explorer
@@ -97,9 +94,9 @@ jobs:
     steps:
       - name: Approve pending deployment
         run: |
-          ENV_ID=$(curl -s -H "Authorization: token ${{ secrets.GH_TOKEN }}" -H "Accept: application/vnd.github.v3+json" "https://api.github.com/repos/hirosystems/explorer/actions/runs/${{ github.run_id }}/pending_deployments" | jq -r '.[0].environment.id // empty')
+          ENV_ID=$(curl -s -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" -H "Accept: application/vnd.github.v3+json" "https://api.github.com/repos/hirosystems/explorer/actions/runs/${{ github.run_id }}/pending_deployments" | jq -r '.[0].environment.id // empty')
           if [[ -n "${ENV_ID}" ]]; then
-            curl -s -X POST -H "Authorization: token ${{ secrets.GH_TOKEN }}" -H "Accept: application/vnd.github.v3+json" "https://api.github.com/repos/hirosystems/explorer/actions/runs/${{ github.run_id }}/pending_deployments" -d "{\"environment_ids\":[${ENV_ID}],\"state\":\"approved\",\"comment\":\"auto approve\"}"
+            curl -s -X POST -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" -H "Accept: application/vnd.github.v3+json" "https://api.github.com/repos/hirosystems/explorer/actions/runs/${{ github.run_id }}/pending_deployments" -d "{\"environment_ids\":[${ENV_ID}],\"state\":\"approved\",\"comment\":\"auto approve\"}"
           fi
 
   deploy-prod:
@@ -119,7 +116,6 @@ jobs:
       - name: Checkout actions repo
         uses: actions/checkout@v3
         with:
-          token: ${{ secrets.GH_TOKEN }}
           repository: ${{ secrets.DEVOPS_ACTIONS_REPO }}
 
       - name: Deploy Explorer


### PR DESCRIPTION
The current settings for the Explorer repo _should_ allow the default GITHUB_TOKEN to do what it needs to do. If not, then we'll have to reintroduce the previous token only where necessary.

Related to https://github.com/hirosystems/devops/issues/1044