### PR TITLE
fix: add error check for non-existent transaction on txid page

### DIFF
--- a/src/pages/txid/[txid].tsx
+++ b/src/pages/txid/[txid].tsx
@@ -29,13 +29,13 @@ const TransactionPage: NextPage<TransactionPageProps> = ({ error, isPossiblyVali
     staleTime: 2000,
   };
 
-  const { data: tx } = useQuery(
+  const { isError: isTxError } = useQuery(
     transactionQK(TransactionQueryKeys.transaction, txid),
     queries.fetchSingleTransaction({ txId: txid }),
     queryOptions
   );
 
-  if (error)
+  if (error || isTxError)
     return (
       <>
         <Meta title="Transaction not found" />


### PR DESCRIPTION
fixes https://github.com/hirosystems/explorer/issues/902

## Issue
`useQuery` fetches the non-existent tx several times, but the component doesn't handle the error state so it looks like it's loading forever.

## Solution
added an error check so that after a few failed fetching attempts it would display the `TxNotFound` component.

## Demo
https://user-images.githubusercontent.com/16448321/199724219-4b792288-1ade-4759-a1e7-588721595840.mp4

local test url: http://localhost:3000/txid/0xbb7bcc79a698c665edcd01b934967b012c5329ba6b88356f4bf50ab0d9551e61?chain=mainnet


