### PR TITLE
fix: handle tuple result when value is 'none'

### DIFF
--- a/src/components/function-summary/result.tsx
+++ b/src/components/function-summary/result.tsx
@@ -1,4 +1,4 @@
-import { cvToJSON, hexToCV } from '@stacks/transactions';
+import { cvToJSON, hexToCV, ClarityAbiType, ClarityAbiTypeTuple } from '@stacks/transactions';
 import type { Transaction } from '@stacks/stacks-blockchain-api-types';
 import { Box, Flex, Stack, color } from '@stacks/ui';
 import { Caption, Pre } from '@components/typography';
@@ -24,7 +24,7 @@ export const FunctionSummaryResult = ({ result, txStatus }: FunctionSummaryResul
           {Object.keys(value.value).map((name: string, index: number) => {
             const isLast = Object.keys(value.value).length <= index + 1;
             const entry = value.value[name];
-            let repr = entry.value.toString();
+            let repr = entry.value === null ? 'none' : entry.value.toString();
             if (entry.type.includes('list')) {
               repr = entry.value.map((listEntry: any) => listEntry.value).join(', ');
             }

--- a/src/components/function-summary/result.tsx
+++ b/src/components/function-summary/result.tsx
@@ -1,4 +1,4 @@
-import { cvToJSON, hexToCV, ClarityAbiType, ClarityAbiTypeTuple } from '@stacks/transactions';
+import { cvToJSON, hexToCV } from '@stacks/transactions';
 import type { Transaction } from '@stacks/stacks-blockchain-api-types';
 import { Box, Flex, Stack, color } from '@stacks/ui';
 import { Caption, Pre } from '@components/typography';


### PR DESCRIPTION
I ran into this bug with a contract call that has a "tuple" return type, and one of the keys has a 'none' value. The page crashes in that case.

This was just on my local devnet, so I don't have a public reproduction available unfortunately.

I remember this code 😅 it's such a nightmare to get strong types