### PR TITLE
fix: max events in tx api request

### DIFF
--- a/src/common/constants.ts
+++ b/src/common/constants.ts
@@ -103,7 +103,7 @@ export const QueryRefreshRates: Record<'Default' | 'None', number | false> = {
 export const DEFAULT_BLOCKS_LIST_LIMIT = 11;
 export const DEFAULT_LIST_LIMIT_SMALL = 10;
 export const DEFAULT_LIST_LIMIT = 30;
-export const DEFAULT_TX_EVENTS_LIMIT = 100;
+export const DEFAULT_TX_EVENTS_LIMIT = 50;
 
 export const MAX_BLOCK_TRANSACTIONS_PER_CALL = 200;
 


### PR DESCRIPTION
It looks like the maximum `events_limit` param recently changed to 50 (from 200?) in the `stacks-2.1` branch of the API. https://github.com/hirosystems/stacks-blockchain-api/commit/0203d36342569803db6a59a64193ae02f7fc4098

I'm running the explorer via `clarinet integrate` on Stacks 2.1, and any transaction page fails because the API throws due to `event_limit` being over the maximum.