### PR TITLE
Fix: network switching

### DIFF
--- a/src/common/api/utils.ts
+++ b/src/common/api/utils.ts
@@ -1,7 +1,7 @@
 import { Transaction } from '@stacks/stacks-blockchain-api-types';
 import { ChainID } from '@stacks/transactions';
 
-import { NetworkModes } from '@common/types/network';
+import { NetworkMode, NetworkModes } from '@common/types/network';
 
 export const constructLimitAndOffsetQueryParams = (limit: number, offset?: number): string =>
   `limit=${limit}${offset ? `&offset=${offset}` : ''}`;
@@ -15,12 +15,14 @@ export const generateTypesQueryString = (types?: Transaction['tx_type'][]) => {
   return '';
 };
 
-export const getNetworkModeFromNetworkId = (networkId: ChainID) => {
+export const getNetworkModeFromNetworkId = (networkId: ChainID): NetworkModes | undefined => {
   switch (networkId) {
     case ChainID.Mainnet:
       return NetworkModes.Mainnet;
     case ChainID.Testnet:
       return NetworkModes.Testnet;
+    case ChainID.Devnet:
+      return NetworkModes.Devnet;
     default:
       return undefined;
   }

--- a/src/common/api/utils.ts
+++ b/src/common/api/utils.ts
@@ -1,7 +1,7 @@
 import { Transaction } from '@stacks/stacks-blockchain-api-types';
 import { ChainID } from '@stacks/transactions';
 
-import { NetworkMode, NetworkModes } from '@common/types/network';
+import { NetworkModes } from '@common/types/network';
 
 export const constructLimitAndOffsetQueryParams = (limit: number, offset?: number): string =>
   `limit=${limit}${offset ? `&offset=${offset}` : ''}`;

--- a/src/common/api/utils.ts
+++ b/src/common/api/utils.ts
@@ -21,8 +21,6 @@ export const getNetworkModeFromNetworkId = (networkId: ChainID): NetworkModes | 
       return NetworkModes.Mainnet;
     case ChainID.Testnet:
       return NetworkModes.Testnet;
-    case ChainID.Devnet:
-      return NetworkModes.Devnet;
     default:
       return undefined;
   }

--- a/src/common/constants/network.ts
+++ b/src/common/constants/network.ts
@@ -10,7 +10,6 @@ import { NetworkModes } from '@common/types/network';
 export const NetworkIdModeMap: { [key in ChainID]: NetworkModes } = {
   [ChainID.Mainnet]: NetworkModes.Mainnet,
   [ChainID.Testnet]: NetworkModes.Testnet,
-  [ChainID.Devnet]: NetworkModes.Devnet,
 };
 
 export const NetworkModeUrlMap: Record<NetworkModes, string> = {

--- a/src/common/constants/network.ts
+++ b/src/common/constants/network.ts
@@ -1,16 +1,22 @@
 import { ChainID } from '@stacks/transactions';
 
-import { DEFAULT_MAINNET_SERVER, DEFAULT_TESTNET_SERVER } from '@common/constants';
+import {
+  DEFAULT_DEVNET_SERVER,
+  DEFAULT_MAINNET_SERVER,
+  DEFAULT_TESTNET_SERVER,
+} from '@common/constants';
 import { NetworkModes } from '@common/types/network';
 
 export const NetworkIdModeMap: { [key in ChainID]: NetworkModes } = {
   [ChainID.Mainnet]: NetworkModes.Mainnet,
   [ChainID.Testnet]: NetworkModes.Testnet,
+  [ChainID.Devnet]: NetworkModes.Devnet,
 };
 
 export const NetworkModeUrlMap: Record<NetworkModes, string> = {
   [NetworkModes.Mainnet]: DEFAULT_MAINNET_SERVER,
   [NetworkModes.Testnet]: DEFAULT_TESTNET_SERVER,
+  [NetworkModes.Devnet]: DEFAULT_DEVNET_SERVER,
 };
 
 export const CustomNetworksLSKey = 'CustomNetworks';

--- a/src/common/state/network-slice.ts
+++ b/src/common/state/network-slice.ts
@@ -112,9 +112,9 @@ export const selectNetworks = createSelector([selectNetworkSlice], networkSlice 
     networkId: ChainID.Testnet,
     mode: NetworkModes.Testnet,
   },
-  [DEFAULT_DEVNET_SERVER]: {
+  [networkSlice.apiUrls[NetworkModes.Devnet]]: {
     label: 'devnet',
-    url: DEFAULT_DEVNET_SERVER,
+    url: networkSlice.apiUrls[NetworkModes.Devnet],
     networkId: ChainID.Devnet,
     mode: NetworkModes.Devnet,
   },

--- a/src/common/state/network-slice.ts
+++ b/src/common/state/network-slice.ts
@@ -113,7 +113,7 @@ export const selectNetworks = createSelector([selectNetworkSlice], networkSlice 
   [networkSlice.apiUrls[NetworkModes.Devnet]]: {
     label: 'devnet',
     url: networkSlice.apiUrls[NetworkModes.Devnet],
-    networkId: ChainID.Devnet,
+    networkId: ChainID.Testnet,
     mode: NetworkModes.Devnet,
   },
   ...networkSlice.customNetworks,

--- a/src/common/state/network-slice.ts
+++ b/src/common/state/network-slice.ts
@@ -11,6 +11,7 @@ import { getCustomNetworksFromLS } from '@common/utils';
 export interface ApiUrls {
   [NetworkModes.Mainnet]: string;
   [NetworkModes.Testnet]: string;
+  [NetworkModes.Devnet]: string;
 }
 
 export interface NetworkState {
@@ -25,6 +26,7 @@ const initialState: NetworkState = {
   apiUrls: {
     [NetworkModes.Mainnet]: '',
     [NetworkModes.Testnet]: '',
+    [NetworkModes.Devnet]: '',
   },
   activeNetworkKey: '',
   customNetworks: getCustomNetworksFromLS(),
@@ -111,8 +113,8 @@ export const selectNetworks = createSelector([selectNetworkSlice], networkSlice 
   [DEFAULT_DEVNET_SERVER]: {
     label: 'devnet',
     url: DEFAULT_DEVNET_SERVER,
-    networkId: ChainID.Testnet,
-    mode: NetworkModes.Testnet,
+    networkId: ChainID.Devnet,
+    mode: NetworkModes.Devnet,
   },
   ...networkSlice.customNetworks,
 }));

--- a/src/common/state/network-slice.ts
+++ b/src/common/state/network-slice.ts
@@ -34,13 +34,11 @@ const initialState: NetworkState = {
 
 const RELOAD_DELAY = 500;
 
-const reloadWithNewNetwork = (
-  network: Network // TODO: probably the issue
-) =>
+const reloadWithNewNetwork = (network: Network) =>
   setTimeout(() => {
     if (typeof window !== 'undefined') {
       const href = new URL(window.location.href);
-      href.searchParams.set('chain', network.mode); // TODO: this is my fix for url
+      href.searchParams.set('chain', network.mode);
       if (network.isCustomNetwork) {
         href.searchParams.set('api', network.url);
       } else {

--- a/src/common/state/network-slice.ts
+++ b/src/common/state/network-slice.ts
@@ -34,11 +34,13 @@ const initialState: NetworkState = {
 
 const RELOAD_DELAY = 500;
 
-const reloadWithNewNetwork = (network: Network) =>
+const reloadWithNewNetwork = (
+  network: Network // TODO: probably the issue
+) =>
   setTimeout(() => {
     if (typeof window !== 'undefined') {
       const href = new URL(window.location.href);
-      href.searchParams.set('chain', network.mode);
+      href.searchParams.set('chain', network.mode); // TODO: this is my fix for url
       if (network.isCustomNetwork) {
         href.searchParams.set('api', network.url);
       } else {

--- a/src/common/types/network.ts
+++ b/src/common/types/network.ts
@@ -2,10 +2,11 @@ import { ChainID } from '@stacks/transactions';
 
 export enum NetworkModes {
   Testnet = 'testnet',
+  Devnet = 'devnet',
   Mainnet = 'mainnet',
 }
 
-export type NetworkMode = NetworkModes.Mainnet | NetworkModes.Testnet;
+export type NetworkMode = NetworkModes.Mainnet | NetworkModes.Testnet | NetworkModes.Devnet;
 
 export interface Network {
   label: string;

--- a/src/components/meta-head.tsx
+++ b/src/components/meta-head.tsx
@@ -35,6 +35,8 @@ export const Meta = ({
   const withMode = (title: string) => {
     if (network.mode === 'testnet') {
       return `${title} [Testnet mode]`;
+    } else if (network.mode === 'devnet') {
+      return `${title} [Devnet mode]`;
     }
     return title;
   };

--- a/src/components/network-items.tsx
+++ b/src/components/network-items.tsx
@@ -68,20 +68,18 @@ const NetworkItem: React.FC<ItemProps> = ({
   const isMainnet = networkItem.url === mainnet;
   const isTestnet = networkItem.url === testnet;
   const isDefault = isMainnet || isTestnet;
-  let networkItemMode: NetworkModes | undefined = networkItem.mode;
+  const networkItemMode: NetworkModes = networkItem.mode;
 
   const doNotFetch = isDisabled || !networkItem.url || isDefault;
-
   const { data, error } = useSWR(!!doNotFetch ? null : networkItem.url, async () => {
     // this will only run if the item url is not one of the defaults (mainnet/testnet)
     const response = await fetchFromApi(networkItem.url)(DEFAULT_V2_INFO_ENDPOINT);
     return response.json();
   });
-
   // Custom network id
-  if (!isDefault && data) {
-    networkItemMode = getNetworkModeFromNetworkId(data?.network_id && parseInt(data?.network_id));
-  }
+  const customNetworkItemId =
+    !isDefault && data ? data?.network_id && parseInt(data?.network_id) : undefined;
+  const customNetworkItemMode = getNetworkModeFromNetworkId(customNetworkItemId as ChainID);
 
   const handleClick = React.useCallback(
     e => {
@@ -111,9 +109,9 @@ const NetworkItem: React.FC<ItemProps> = ({
       >
         <Flex alignItems="center">
           <Title display="block">{networkItem.label}</Title>
-          {networkItemMode ? (
+          {networkItemMode || customNetworkItemMode ? (
             <Badge bg={color('bg-4')} ml="tight" border={border()} color={color('text-caption')}>
-              {networkItemMode}
+              {networkItemMode || customNetworkItemMode}
             </Badge>
           ) : null}
         </Flex>

--- a/src/components/network-mode-banner.tsx
+++ b/src/components/network-mode-banner.tsx
@@ -11,7 +11,7 @@ import { Badge, BadgeProps } from '@components/badge';
 
 export const NetworkModeBanner: React.FC<BadgeProps> = props => {
   const networkMode = useAppSelector(selectActiveNetwork).mode;
-  return networkMode === 'testnet' ? (
+  return networkMode === 'testnet' || networkMode === 'devnet' ? (
     <Badge flexShrink={0} bg="white" {...props}>
       <Flex alignItems="center">
         <Box

--- a/src/modules/sandbox/hooks/useUser.ts
+++ b/src/modules/sandbox/hooks/useUser.ts
@@ -66,7 +66,7 @@ export const useUser = () => {
     hasTransactions:
       !!transactionsData?.results?.length || !!mempoolTransactionsData?.results?.length,
     connect: (authOptions?: Partial<AuthOptions>) =>
-      dispatch(connect({ activeNetworkMode: activeNetworkMode, authOptions: authOptions })),
+      dispatch(connect({ activeNetworkMode, authOptions })),
     disconnect: () => dispatch(disconnect()),
   };
 };

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -111,7 +111,7 @@ ExplorerApp.getInitialProps = async (appContext: AppContext) => {
     : networkModeFromNextUrl
     ? networkModeFromNextUrl
     : NetworkModes.Mainnet;
- 
+
   const queryApiUrl = Array.isArray(query.api)
     ? query.api[0]
     : query.api

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -98,38 +98,11 @@ ExplorerApp.getInitialProps = async (appContext: AppContext) => {
 
   const query = appContext.ctx.query;
 
-  const nextUrl = appContext.ctx.req?.url || '';
+  const nextUrl = appContext.ctx.req?.url;
   const searchParams = getSearchParamsFromNextUrl(nextUrl);
   const chain = searchParams.chain;
   const networkModeFromNextUrl = chain ? getNetworkMode(chain) : undefined;
   const api = searchParams.api;
-
-  // const nextUrl = new URL(appContext.ctx.req?.url ?? '');
-  // const chain = nextUrl.searchParams.get('chain');
-  // const networkModeFromNextUrl = chain ? getNetworkMode(chain) : undefined;
-  // const api = nextUrl.searchParams.get('api');
-
-  // const nextUrl = appContext.ctx.req?.url;
-  // const nextUrl = window.location;
-
-  // const searchParams = new URLSearchParams(nextUrl ?? '');
-  // const chain = searchParams.get('chain');
-  // const networkModeFromNextUrl = chain ? getNetworkMode(chain) : undefined;
-  // const api = searchParams.get('api');
-
-  // console.log({
-  //   nextUrl,
-  //   searchParams,
-  //   chain,
-  //   networkModeFromNextUrl,
-  //   api,
-  //   queryChain: query.chain,
-  //   queryApi: query.api,
-  //   keys: searchParams.keys(),
-  //   url: appContext.ctx.req?.url,
-  //   query: appContext.ctx.query,
-  //   windowLocation: window.location,
-  // });
 
   const queryNetworkMode = Array.isArray(query.chain)
     ? (query.chain[0] as NetworkModes)
@@ -138,10 +111,7 @@ ExplorerApp.getInitialProps = async (appContext: AppContext) => {
     : networkModeFromNextUrl
     ? networkModeFromNextUrl
     : NetworkModes.Mainnet;
-  // const queryNetworkMode = Array.isArray(query.chain)
-  //   ? (query.chain[0] as NetworkModes)
-  //   : (query.chain as NetworkModes);
-
+ 
   const queryApiUrl = Array.isArray(query.api)
     ? query.api[0]
     : query.api
@@ -149,7 +119,6 @@ ExplorerApp.getInitialProps = async (appContext: AppContext) => {
     : api
     ? api
     : undefined;
-  // const queryApiUrl = Array.isArray(query.api) ? query.api[0] : query.api;
 
   store.dispatch(initialize({ queryNetworkMode, apiUrls: NetworkModeUrlMap, queryApiUrl }));
   console.log(

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -1,3 +1,4 @@
+import { createTxFilterSlice } from '@features/transactions-filter/transactions-filter-slice';
 import 'modern-normalize/modern-normalize.css';
 import type { AppContext, AppProps } from 'next/app';
 import App from 'next/app';
@@ -60,6 +61,22 @@ function ExplorerApp({ Component, ...rest }: ExplorerAppProps) {
   );
 }
 
+const getSearchParamsFromNextUrl = (url: string | undefined) => {
+  if (!url) {
+    return {};
+  }
+  const searchParamsString = url.split('?')[1];
+  const searchParamsArray = searchParamsString.split('&');
+  const searchParams: Record<string, string> = {};
+  searchParamsArray.forEach(param => {
+    const keyValueTuple = param.split('=');
+    const key = keyValueTuple[0];
+    const value = keyValueTuple[1];
+    searchParams[key] = value;
+  });
+  return searchParams;
+};
+
 const getNetworkMode = (chain: string) => {
   if (chain === NetworkModes.Devnet) return NetworkModes.Devnet;
   else if (chain === NetworkModes.Mainnet) return NetworkModes.Mainnet;
@@ -72,10 +89,32 @@ ExplorerApp.getInitialProps = async (appContext: AppContext) => {
 
   const query = appContext.ctx.query;
 
-  const nextUrl = new URL(appContext.ctx.req?.url ?? '');
-  const chain = nextUrl.searchParams.get('chain');
+  // const nextUrl = new URL(appContext.ctx.req?.url ?? '');
+  // const chain = nextUrl.searchParams.get('chain');
+  // const networkModeFromNextUrl = chain ? getNetworkMode(chain) : undefined;
+  // const api = nextUrl.searchParams.get('api');
+
+  // const nextUrl = appContext.ctx.req?.url;
+  // const nextUrl = window.location;
+
+  const searchParams = new URLSearchParams(nextUrl ?? '');
+  const chain = searchParams.get('chain');
   const networkModeFromNextUrl = chain ? getNetworkMode(chain) : undefined;
-  const api = nextUrl.searchParams.get('api');
+  const api = searchParams.get('api');
+
+  console.log({
+    nextUrl,
+    searchParams,
+    chain,
+    networkModeFromNextUrl,
+    api,
+    queryChain: query.chain,
+    queryApi: query.api,
+    keys: searchParams.keys(),
+    url: appContext.ctx.req?.url,
+    query: appContext.ctx.query,
+    windowLocation: window.location,
+  });
 
   const queryNetworkMode = Array.isArray(query.chain)
     ? (query.chain[0] as NetworkModes)

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -66,7 +66,15 @@ const getSearchParamsFromNextUrl = (url: string | undefined) => {
     return {};
   }
   const searchParamsString = url.split('?')[1];
+  if (!searchParamsString) {
+    return {};
+  }
+
   const searchParamsArray = searchParamsString.split('&');
+  if (!searchParamsArray) {
+    return {};
+  }
+
   const searchParams: Record<string, string> = {};
   searchParamsArray.forEach(param => {
     const keyValueTuple = param.split('=');
@@ -74,6 +82,7 @@ const getSearchParamsFromNextUrl = (url: string | undefined) => {
     const value = keyValueTuple[1];
     searchParams[key] = value;
   });
+
   return searchParams;
 };
 
@@ -89,6 +98,12 @@ ExplorerApp.getInitialProps = async (appContext: AppContext) => {
 
   const query = appContext.ctx.query;
 
+  const nextUrl = appContext.ctx.req?.url || '';
+  const searchParams = getSearchParamsFromNextUrl(nextUrl);
+  const chain = searchParams.chain;
+  const networkModeFromNextUrl = chain ? getNetworkMode(chain) : undefined;
+  const api = searchParams.api;
+
   // const nextUrl = new URL(appContext.ctx.req?.url ?? '');
   // const chain = nextUrl.searchParams.get('chain');
   // const networkModeFromNextUrl = chain ? getNetworkMode(chain) : undefined;
@@ -97,24 +112,24 @@ ExplorerApp.getInitialProps = async (appContext: AppContext) => {
   // const nextUrl = appContext.ctx.req?.url;
   // const nextUrl = window.location;
 
-  const searchParams = new URLSearchParams(nextUrl ?? '');
-  const chain = searchParams.get('chain');
-  const networkModeFromNextUrl = chain ? getNetworkMode(chain) : undefined;
-  const api = searchParams.get('api');
+  // const searchParams = new URLSearchParams(nextUrl ?? '');
+  // const chain = searchParams.get('chain');
+  // const networkModeFromNextUrl = chain ? getNetworkMode(chain) : undefined;
+  // const api = searchParams.get('api');
 
-  console.log({
-    nextUrl,
-    searchParams,
-    chain,
-    networkModeFromNextUrl,
-    api,
-    queryChain: query.chain,
-    queryApi: query.api,
-    keys: searchParams.keys(),
-    url: appContext.ctx.req?.url,
-    query: appContext.ctx.query,
-    windowLocation: window.location,
-  });
+  // console.log({
+  //   nextUrl,
+  //   searchParams,
+  //   chain,
+  //   networkModeFromNextUrl,
+  //   api,
+  //   queryChain: query.chain,
+  //   queryApi: query.api,
+  //   keys: searchParams.keys(),
+  //   url: appContext.ctx.req?.url,
+  //   query: appContext.ctx.query,
+  //   windowLocation: window.location,
+  // });
 
   const queryNetworkMode = Array.isArray(query.chain)
     ? (query.chain[0] as NetworkModes)
@@ -123,6 +138,10 @@ ExplorerApp.getInitialProps = async (appContext: AppContext) => {
     : networkModeFromNextUrl
     ? networkModeFromNextUrl
     : NetworkModes.Mainnet;
+  // const queryNetworkMode = Array.isArray(query.chain)
+  //   ? (query.chain[0] as NetworkModes)
+  //   : (query.chain as NetworkModes);
+
   const queryApiUrl = Array.isArray(query.api)
     ? query.api[0]
     : query.api
@@ -130,6 +149,7 @@ ExplorerApp.getInitialProps = async (appContext: AppContext) => {
     : api
     ? api
     : undefined;
+  // const queryApiUrl = Array.isArray(query.api) ? query.api[0] : query.api;
 
   store.dispatch(initialize({ queryNetworkMode, apiUrls: NetworkModeUrlMap, queryApiUrl }));
   console.log(

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -60,7 +60,10 @@ function ExplorerApp({ Component, ...rest }: ExplorerAppProps) {
   );
 }
 
-const getSearchParamsFromUrl = (url: string) => {
+const getSearchParamsFromNextUrl = (url: string | undefined) => {
+  if (!url) {
+    return {};
+  }
   const searchParamsString = url.split('?')[1];
   const searchParamsArray = searchParamsString.split('&');
   const searchParams: Record<string, string> = {};
@@ -83,17 +86,18 @@ const getNetworkMode = (chain: string) => {
 ExplorerApp.getInitialProps = async (appContext: AppContext) => {
   const appProps = await App.getInitialProps(appContext);
 
-  const nextUrl = appContext.ctx.req?.url;
-  let chain = '',
-    api = '';
-  if (nextUrl) {
-    const searchParams = getSearchParamsFromUrl(nextUrl);
-    chain = searchParams.chain;
-    api = searchParams.api;
-  }
   const query = appContext.ctx.query;
-  const queryNetworkMode = getNetworkMode(chain) ?? NetworkModes.Mainnet;
-  const queryApiUrl = api;
+
+  const nextUrl = appContext.ctx.req?.url;
+  const searchParams = getSearchParamsFromNextUrl(nextUrl);
+  const chain = searchParams.chain;
+  const api = searchParams.api;
+
+  const queryNetworkMode =
+    ((Array.isArray(query.chain) ? query.chain[0] : query.chain) as NetworkModes) ||
+    getNetworkMode(chain) ||
+    NetworkModes.Mainnet;
+  const queryApiUrl = Array.isArray(query.api) ? query.api[0] : query.api ? api : undefined;
 
   store.dispatch(initialize({ queryNetworkMode, apiUrls: NetworkModeUrlMap, queryApiUrl }));
   console.log(


### PR DESCRIPTION
Addresss issues:
closes #949, #950, and #955

Issue:
The network switcher in the header was not working. The two main issues I identified were:
1. The initial bootstrapping of the app was not respecting the chain search param in the url. The query object from Nextjs is undefined
2. In multiple places in the code, "devnet" was not regarded as a valid network mode, which resulted in UIs that were confusing because the devnet network would be selected, but the UI would display labels for testnet.

Solution: 
1. I am manually checking the url search params and reconciliing my results with nextjs's results
2. I made devnet a first class citizen as far as networking modes go

Testing:
I am manually testing that the issues noted above have been fixed