### PR TITLE
fix(disabled-pc): Disabled Post Condition Button should not be clickable

### DIFF
--- a/src/modules/sandbox/components/ContractCall/FunctionView.tsx
+++ b/src/modules/sandbox/components/ContractCall/FunctionView.tsx
@@ -594,8 +594,7 @@ export const FunctionView: FC<FunctionViewProps> = ({ fn, contractId, cancelButt
 };
 
 const PostConditionButton = styled(Button, {
-  shouldForwardProp: propName =>
-    propName !== 'disabled' && propName !== 'showPostCondition' && propName !== 'colorMode',
+  shouldForwardProp: propName => propName !== 'showPostCondition' && propName !== 'colorMode',
 })<{
   disabled: boolean;
   showPostCondition: boolean;


### PR DESCRIPTION
Fixes the issue where you can still click the "Add Post Condition" button even though it is disabled.