### PR TITLE
Add arm64 build arg and update action versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,6 +57,9 @@ jobs:
         with:
           ref: v${{ steps.semantic.outputs.new_release_version }}
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+        
       - name: Docker meta
         id: docker_meta
         uses: docker/metadata-action@v3
@@ -69,14 +72,14 @@ jobs:
             type=semver,pattern={{major}}.{{minor}},value=${{ steps.semantic.outputs.new_release_version }},enable=${{ steps.semantic.outputs.new_release_version != '' }}
 
       - name: Login to Dockerhub
-        uses: docker/login-action@v1
+        uses: docker/login-action@v2
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_PASSWORD }}
 
       - name: Build/Tag/Push Image
         id: docker_push
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v3
         with:
           push: true
           platforms: linux/arm64, linux/amd64, linux/amd64/v2, linux/amd64/v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,6 +79,7 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           push: true
+          platforms: linux/arm64, linux/amd64, linux/amd64/v2, linux/amd64/v3
           tags: ${{ steps.docker_meta.outputs.tags }}
           labels: ${{ steps.docker_meta.outputs.labels }}
           build-args: |


### PR DESCRIPTION
Very similar in scope to: https://github.com/hirosystems/stacks-blockchain-api/pull/1578


Two changes being proposed here:
1. adding an arm64 platform for the docker image being built platforms: linux/arm64, linux/amd64
2. update the actions to use latest versions (i.e. docker/build-push-action@v2 -> docker/build-push-action@v3)

Note that I wasn't able to successfully build this image locally though, and the error output was not helpful. However, i think it's related to the sentry env vars (there was no error logged):
```
[4/4] Building fresh packages...
[1/5] ⠠ @sentry/cli
[2/5] ⠠ bufferutil
[3/5] ⠠ iltorb
[-/5] ⠠ waiting...
error /app/node_modules/@sentry/cli: Command failed.
Exit code: 1
Command: node ./scripts/install.js
Arguments: 
Directory: /app/node_modules/@sentry/cli
Output:



```


I suspect that with correct sentry args/secrets, this repo would build correctly using these changes. 

