### PR TITLE
fix(sandbox): handle optional function args (#956)

### DIFF
--- a/src/app/sandbox/components/ContractCall/FunctionView.tsx
+++ b/src/app/sandbox/components/ContractCall/FunctionView.tsx
@@ -21,7 +21,7 @@ import {
 
 import { useStacksNetwork } from '../../../common/hooks/use-stacks-network';
 import { ListValueType, NonTupleValueType, TupleValueType, ValueType } from '../../types/values';
-import { encodeTuple, getTuple } from '../../utils';
+import { encodeOptional, encodeTuple, getTuple } from '../../utils';
 import { Argument } from '../Argument';
 import { ReadOnlyField } from './ReadOnlyField';
 
@@ -105,11 +105,10 @@ export const FunctionView: FC<FunctionViewProps> = ({ fn, contractId, cancelButt
                   )
             );
             final[arg] = listCV(listData);
+          } else if (optionalType) {
+            final[arg] = encodeOptional(optionalType, values[arg] as NonTupleValueType);
           } else {
-            final[arg] = encodeClarityValue(
-              optionalType || type,
-              (values[arg] as NonTupleValueType).toString()
-            );
+            final[arg] = encodeClarityValue(type, (values[arg] as NonTupleValueType).toString());
           }
         });
         if (fn.access === 'public') {

--- a/src/app/sandbox/utils.ts
+++ b/src/app/sandbox/utils.ts
@@ -10,11 +10,13 @@ import {
   encodeClarityValue,
   isClarityAbiOptional,
   isClarityAbiTuple,
+  noneCV,
   serializeCV,
+  someCV,
   tupleCV,
 } from '@stacks/transactions';
 
-import { TupleValueType } from './types/values';
+import { NonTupleValueType, TupleValueType } from './types/values';
 
 export interface ClarityFunctionArg {
   name: string;
@@ -93,4 +95,12 @@ export const encodeTuple = (tuple: ClarityAbiTypeTuple['tuple'], value: TupleVal
     return acc;
   }, {} as Record<string, ClarityValue>);
   return tupleCV(tupleData);
+};
+
+export const encodeOptional = (optionalType: ClarityAbiType, value: NonTupleValueType) => {
+  if (value) {
+    return someCV(encodeClarityValue(optionalType, value.toString()));
+  } else {
+    return noneCV();
+  }
 };


### PR DESCRIPTION
This PR
* handles non-tuple optional function arguments in the sandbox

This change is important for using city coin contracts, wrapper pox contracts, etc.