### PR TITLE
fix(sandbox): handle optional tuples better

### DIFF
--- a/src/app/sandbox/components/Argument/TupleArgumentInput.tsx
+++ b/src/app/sandbox/components/Argument/TupleArgumentInput.tsx
@@ -17,6 +17,7 @@ export const TupleArgumentInput: FC<
   }
 > = ({ name, type, handleChange, error, value, tuple }) => {
   const isOptional = isClarityAbiOptional(type);
+  const tupleType = isOptional ? (type.optional as ClarityAbiTypeTuple) : type;
   return (
     <Box>
       <Stack id={name} isInline spacing="16px" width="100%">
@@ -37,12 +38,12 @@ export const TupleArgumentInput: FC<
             <Box width="100%">
               <Input
                 width="100%"
-                type={getTypeString(type.tuple[i].type).includes('int') ? 'number' : 'text'}
+                type={getTypeString(tupleType.tuple[i].type).includes('int') ? 'number' : 'text'}
                 name={`${name}.${tupleEntry.name}`}
                 id={name}
                 onChange={handleChange}
                 value={value[tupleEntry.name]}
-                placeholder={`${getTypeString(type.tuple[i].type)}`}
+                placeholder={`${getTypeString(tupleType.tuple[i].type)}`}
               />
               {error && <Caption color={'feedbackError'}>{error}</Caption>}
             </Box>

--- a/src/app/sandbox/components/ContractCall/FunctionView.tsx
+++ b/src/app/sandbox/components/ContractCall/FunctionView.tsx
@@ -17,11 +17,12 @@ import {
   isClarityAbiOptional,
   isClarityAbiPrimitive,
   listCV,
+  someCV,
 } from '@stacks/transactions';
 
 import { useStacksNetwork } from '../../../common/hooks/use-stacks-network';
 import { ListValueType, NonTupleValueType, TupleValueType, ValueType } from '../../types/values';
-import { encodeOptional, encodeTuple, getTuple } from '../../utils';
+import { encodeOptional, encodeOptionalTuple, encodeTuple, getTuple } from '../../utils';
 import { Argument } from '../Argument';
 import { ReadOnlyField } from './ReadOnlyField';
 
@@ -88,7 +89,11 @@ export const FunctionView: FC<FunctionViewProps> = ({ fn, contractId, cancelButt
           const isList = isClarityAbiList(type);
           const optionalType = isClarityAbiOptional(type) ? type?.optional : undefined;
           if (tuple) {
-            final[arg] = encodeTuple(tuple, values[arg] as TupleValueType);
+            if (optionalType) {
+              final[arg] = encodeOptionalTuple(tuple, values[arg] as TupleValueType);
+            } else {
+              final[arg] = encodeTuple(tuple, values[arg] as TupleValueType);
+            }
           } else if (isList) {
             const listValues = values[arg] as ListValueType;
             const listType = type.list.type;

--- a/src/app/sandbox/utils.ts
+++ b/src/app/sandbox/utils.ts
@@ -88,7 +88,10 @@ export const getTuple = (type?: ClarityAbiType): ClarityAbiTypeTuple['tuple'] | 
   if (isOptional && isClarityAbiTuple(type?.optional)) return type?.optional?.tuple;
 };
 
-export const encodeTuple = (tuple: ClarityAbiTypeTuple['tuple'], value: TupleValueType) => {
+export const encodeTuple = (
+  tuple: ClarityAbiTypeTuple['tuple'],
+  value: TupleValueType
+): ClarityValue => {
   const tupleData = tuple.reduce((acc, tupleEntry) => {
     const _type = tupleEntry.type;
     acc[tupleEntry.name] = encodeClarityValue(_type, value[tupleEntry.name].toString());
@@ -97,9 +100,27 @@ export const encodeTuple = (tuple: ClarityAbiTypeTuple['tuple'], value: TupleVal
   return tupleCV(tupleData);
 };
 
-export const encodeOptional = (optionalType: ClarityAbiType, value: NonTupleValueType) => {
+export const encodeOptional = (
+  optionalType: ClarityAbiType,
+  value: NonTupleValueType
+): ClarityValue => {
   if (value) {
     return someCV(encodeClarityValue(optionalType, value.toString()));
+  } else {
+    return noneCV();
+  }
+};
+
+const allValuesNotEmpty = (value: TupleValueType) => {
+  return Object.values(value).reduce((previous, value) => previous && value !== '', true);
+};
+
+export const encodeOptionalTuple = (
+  optionalType: ClarityAbiTypeTuple['tuple'],
+  value: TupleValueType
+): ClarityValue => {
+  if (allValuesNotEmpty(value)) {
+    return someCV(encodeTuple(optionalType, value));
   } else {
     return noneCV();
   }


### PR DESCRIPTION
This PR
* fixes #1069 
* adds handling for optional tuples. If one tuple value is empty, the optional tuple is represented as `none`