### PR TITLE
feat: hide pox-2.stack-increase

### DIFF
--- a/src/app/common/utils/sandbox.ts
+++ b/src/app/common/utils/sandbox.ts
@@ -1,0 +1,8 @@
+export function showFn(contractId: string, abiFn: any) {
+  return (
+    abiFn.access !== 'private' &&
+    (abiFn.name !== 'stack-increase' ||
+      (contractId !== 'SP000000000000000000002Q6VF78.pox-2' &&
+        contractId !== 'ST000000000000000000002AMW42H.pox-2'))
+  );
+}

--- a/src/app/common/utils/sandbox.ts
+++ b/src/app/common/utils/sandbox.ts
@@ -1,3 +1,13 @@
+/**
+ * Predicate that a function of a contract should be shown.
+ *
+ * Functions that are private should NOT be shown
+ * Functions that are pox-2.stacks-increase should NOT be shown
+ *
+ * @param contractId the contract id
+ * @param abiFn the abi of the function or
+ * @returns true if the provided function should be shown in the explorer.
+ */
 export function showFn(contractId: string, abiFn: any) {
   return (
     abiFn.access !== 'private' &&

--- a/src/app/common/utils/sandbox.ts
+++ b/src/app/common/utils/sandbox.ts
@@ -2,7 +2,8 @@
  * Predicate that a function of a contract should be shown.
  *
  * Functions that are private should NOT be shown
- * Functions that are pox-2.stacks-increase should NOT be shown
+ * Functions that are pox-2.stacks-increase should NOT be
+ * shown as it is invalid since Stacks 2.2
  *
  * @param contractId the contract id
  * @param abiFn the abi of the function or

--- a/src/app/sandbox/components/ContractCall/AvailableFunctionsView.tsx
+++ b/src/app/sandbox/components/ContractCall/AvailableFunctionsView.tsx
@@ -67,6 +67,15 @@ export const AbiFunction = forwardRef<
   );
 });
 
+function showFn(contractId: string, abiFn: any) {
+  return (
+    abiFn.access !== 'private' &&
+    abiFn.name !== 'stack-increase' &&
+    contractId !== 'SP000000000000000000002Q6VF78.pox-2' &&
+    contractId !== 'ST000000000000000000002AMW42H.pox-2'
+  );
+}
+
 export const AvailableFunctionsView: FC<{
   contract: ContractWithParsedAbi;
   contractId: string;
@@ -74,7 +83,7 @@ export const AvailableFunctionsView: FC<{
   <Section overflowY="auto" flexGrow={1} title="Available functions">
     {contract?.abi?.functions.map(
       (abiFn: any) =>
-        abiFn.access !== 'private' && (
+        hideFn(contractId, abiFn) && (
           <ExplorerLink
             href={`/sandbox/contract-call/${contractId}/${abiFn.name}`}
             key={abiFn.name}

--- a/src/app/sandbox/components/ContractCall/AvailableFunctionsView.tsx
+++ b/src/app/sandbox/components/ContractCall/AvailableFunctionsView.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { showFn } from '@/app/common/utils/sandbox';
 import { Badge } from '@/common/components/Badge';
 import { ContractWithParsedAbi } from '@/common/types/contract';
 import { ArrowRightIcon } from '@/components/icons/arrow-right';
@@ -10,7 +11,7 @@ import { Text } from '@/ui/typography';
 import { forwardRef, useColorMode } from '@chakra-ui/react';
 import { mdiApi, mdiFunction } from '@mdi/js';
 import Icon from '@mdi/react';
-import React, { FC } from 'react';
+import { FC } from 'react';
 
 export const AbiFunction = forwardRef<
   {
@@ -67,15 +68,6 @@ export const AbiFunction = forwardRef<
   );
 });
 
-function showFn(contractId: string, abiFn: any) {
-  return (
-    abiFn.access !== 'private' &&
-    abiFn.name !== 'stack-increase' &&
-    contractId !== 'SP000000000000000000002Q6VF78.pox-2' &&
-    contractId !== 'ST000000000000000000002AMW42H.pox-2'
-  );
-}
-
 export const AvailableFunctionsView: FC<{
   contract: ContractWithParsedAbi;
   contractId: string;
@@ -83,7 +75,7 @@ export const AvailableFunctionsView: FC<{
   <Section overflowY="auto" flexGrow={1} title="Available functions">
     {contract?.abi?.functions.map(
       (abiFn: any) =>
-        hideFn(contractId, abiFn) && (
+        showFn(contractId, abiFn) && (
           <ExplorerLink
             href={`/sandbox/contract-call/${contractId}/${abiFn.name}`}
             key={abiFn.name}

--- a/src/app/sandbox/components/ContractCall/FunctionView.tsx
+++ b/src/app/sandbox/components/ContractCall/FunctionView.tsx
@@ -5,7 +5,7 @@ import { validateStacksAddress } from '@/common/utils';
 import { Section } from '@/components/section';
 import { Box, Button, Flex, Stack } from '@/ui/components';
 import { Form, Formik } from 'formik';
-import React, { FC, ReactNode, useMemo, useState } from 'react';
+import { FC, ReactNode, useMemo, useState } from 'react';
 import { useQueryClient } from 'react-query';
 
 import { openContractCall } from '@stacks/connect';
@@ -17,9 +17,10 @@ import {
   isClarityAbiOptional,
   isClarityAbiPrimitive,
   listCV,
-  someCV,
 } from '@stacks/transactions';
 
+import { showFn } from '@/app/common/utils/sandbox';
+import { Text } from '@/ui/Text';
 import { useStacksNetwork } from '../../../common/hooks/use-stacks-network';
 import { ListValueType, NonTupleValueType, TupleValueType, ValueType } from '../../types/values';
 import { encodeOptional, encodeOptionalTuple, encodeTuple, getTuple } from '../../utils';
@@ -56,6 +57,24 @@ export const FunctionView: FC<FunctionViewProps> = ({ fn, contractId, cancelButt
       }, {} as FormType),
     [fn]
   );
+
+  if (!showFn(contractId, fn)) {
+    return (
+      <Section
+        overflowY="auto"
+        flexGrow={1}
+        title={`${fn.name} (${fn.access} function)`}
+        borderRadius={'0'}
+      >
+        <Box p="32px">
+          <Stack>
+            <Text>Invalid function for {contractId}.</Text>
+            {cancelButton}
+          </Stack>
+        </Box>
+      </Section>
+    );
+  }
 
   return (
     <Formik

--- a/src/app/txid/[txid]/SmartContractPage/ContractTabs.tsx
+++ b/src/app/txid/[txid]/SmartContractPage/ContractTabs.tsx
@@ -4,16 +4,15 @@ import { ContractWithParsedAbi } from '@/common/types/contract';
 import { CodeEditor } from '@/ui/CodeEditor';
 import { Button, Flex, Tab, TabList, TabPanel, TabPanels, Tabs, TextLink } from '@/ui/components';
 import { Caption } from '@/ui/typography';
-import * as React from 'react';
 import { FC, useState } from 'react';
 
 import { ClarityAbiFunction } from '@stacks/transactions';
 
+import { showFn } from '@/app/common/utils/sandbox';
 import { AbiFunction } from '../../../sandbox/components/ContractCall/AvailableFunctionsView';
 import { FunctionView } from '../../../sandbox/components/ContractCall/FunctionView';
 import { useUser } from '../../../sandbox/hooks/useUser';
 import { setUserData } from '../../../sandbox/sandbox-slice';
-
 export const ContractTabs: FC<{
   contractId: string;
   source?: string;
@@ -73,7 +72,7 @@ export const ContractTabs: FC<{
           ) : (
             contract?.abi?.functions.map(
               (abiFn: any) =>
-                abiFn.access !== 'private' && (
+                showFn(contractId, abiFn) && (
                   <AbiFunction
                     key={abiFn.name}
                     abiFn={abiFn}


### PR DESCRIPTION
This PR
* hides pox-2.stacks-increase calls in preparation for Stacks 2.2
  * in the sandbox's list of available functions
  * in the contract page's list of available functions
  * in the sandbox deep link http://localhost:3000/sandbox/contract-call/SP000000000000000000002Q6VF78.pox-2/stack-increase?chain=mainnet
  
![image](https://user-images.githubusercontent.com/1449049/233373319-69cab0ea-3895-4df3-bdaa-d9b58382132a.png)

How to test?
Check the list of available functions on the following pages:
* visit /txid/SP000000000000000000002Q6VF78.pox-2?chain=mainnet 
* visit sandbox/contract-call/SP000000000000000000002Q6VF78.pox-2?chain=mainnet
* visit sandbox/contract-call/SP000000000000000000002Q6VF78.pox-2/stack-increase?chain=mainnet