### PR TITLE
fix: fixed the lastExecutedTxNonce value

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -13,9 +13,9 @@ const customJestConfig = {
   // setupFilesAfterEnv: ['<rootDir>/jest.setup.js'],
 
   testEnvironment: 'jest-environment-jsdom',
-  moduleNameMapper:{
+  moduleNameMapper: {
     '^@/(.*)$': '<rootDir>/src/$1',
-  }
+  },
 };
 
 // createJestConfig is exported this way to ensure that next/jest can load the Next.js config which is async

--- a/src/features/address-page/address-summary.tsx
+++ b/src/features/address-page/address-summary.tsx
@@ -35,11 +35,15 @@ export const AddressSummary = ({
               value={<Value>{`${microToStacks(balances?.stx?.total_fees_sent)} STX`}</Value>}
             />
           )}
-          {lastExecutedTxNonce !== 'undefined' && (
+          {lastExecutedTxNonce !== undefined && (
             <KeyValueHorizontal
               label={'Last executed tx nonce'}
               value={
-                <Value>{lastExecutedTxNonce || "This account hasn't executed a tx yet"}</Value>
+                <Value>
+                  {lastExecutedTxNonce !== null
+                    ? lastExecutedTxNonce.toString()
+                    : "This account hasn't executed a tx yet"}
+                </Value>
               }
             />
           )}


### PR DESCRIPTION
Closes [ Incorrect last executed nonce shown #878  ]
Fixes issue: Incorrect last executed nonce shown

Feature details
Added correct ternary condition. 

Previous Image: 
<img width="519" alt="Screenshot 2023-05-17 at 1 26 20 AM" src="https://github.com/hirosystems/explorer/assets/29030948/c679f3ab-8a75-45cc-b0b9-a125f132f9cd">

Image after fix: 
<img width="517" alt="Screenshot 2023-05-17 at 1 27 04 AM" src="https://github.com/hirosystems/explorer/assets/29030948/e070ccde-0c36-44a7-b9ed-5f16ae5ab1a4">


File changed
`explorer/src/features/address-page/address-summary.tsx`