### PR TITLE
fix: added proper hexadecimal notation for colors

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -13,9 +13,9 @@ const customJestConfig = {
   // setupFilesAfterEnv: ['<rootDir>/jest.setup.js'],
 
   testEnvironment: 'jest-environment-jsdom',
-  moduleNameMapper:{
+  moduleNameMapper: {
     '^@/(.*)$': '<rootDir>/src/$1',
-  }
+  },
 };
 
 // createJestConfig is exported this way to ensure that next/jest can load the Next.js config which is async

--- a/src/app/sandbox/components/ContractCall/DefaultView/SearchContractsForm.tsx
+++ b/src/app/sandbox/components/ContractCall/DefaultView/SearchContractsForm.tsx
@@ -85,7 +85,7 @@ export const SearchContractsForm: FC<{ rootContractAddress: string }> = ({
                   onBlur={handleBlur}
                   value={values.principal}
                   placeholder="Enter the contract address"
-                  color={colorMode === 'light' ? '#000' : '#fff'}
+                  color={colorMode === 'light' ? '#000000' : '#FFFFFF'}
                   onPaste={(e: React.ClipboardEvent<HTMLInputElement>) =>
                     onPaste(e, (value: string) => {
                       const cleanValue = value.trim().toString();
@@ -110,7 +110,7 @@ export const SearchContractsForm: FC<{ rootContractAddress: string }> = ({
                   onBlur={handleBlur}
                   value={values.contract_name}
                   placeholder="Enter the contract name"
-                  color={colorMode === 'light' ? '#000' : '#fff'}
+                  color={colorMode === 'light' ? '#000000' : '#FFFFFF'}
                 />
                 <Box>
                   <Button onClick={() => handleSubmit()}>Get contract</Button>

--- a/src/app/sandbox/editor-config/define-theme.ts
+++ b/src/app/sandbox/editor-config/define-theme.ts
@@ -13,7 +13,7 @@ export function defineTheme(monaco: Monaco) {
       'diffEditor.insertedTextBackground': '#00809b33',
       'dropdown.background': '#1d1f23',
       'dropdown.border': '#181a1f',
-      'editor.background': '#000',
+      'editor.background': '#000000',
       'editor.findMatchBackground': '#42557b',
       'editor.findMatchHighlightBackground': '#314365',
       'editor.lineHighlightBackground': '#383e4a',

--- a/src/features/status-bar/status-bar.tsx
+++ b/src/features/status-bar/status-bar.tsx
@@ -64,7 +64,7 @@ export const StatusBar: FC = () => {
             {description}
             {description.endsWith('.') ? '' : '.'}
           </Text>{' '}
-          <Text fontWeight={400} fontSize={'14px'} color={'#000'} lineHeight={'1.5'}>
+          <Text fontWeight={400} fontSize={'14px'} color={'#000000'} lineHeight={'1.5'}>
             More information on the{' '}
             <TextLink
               href="https://status.hiro.so/"


### PR DESCRIPTION
Closes [ Explorer dev Error: Illegal value for token color: #000 #1140 ]
Fixes issue: Explorer dev Error: Illegal value for token color: # 000

Feature details
Added proper hexadecimal notation for colors.

In most cases, colors are represented using different color models such as RGB (Red, Green, Blue) or hexadecimal notation. In the case of hexadecimal notation, colors are represented by a six-digit code preceded by a hash symbol (#), such as #000000 for black.
