### PR TITLE
fix: handled fetcher function gracefully

### DIFF
--- a/src/common/api/fetch.ts
+++ b/src/common/api/fetch.ts
@@ -15,8 +15,8 @@ export const fetcher = async (input: RequestInfo, init: RequestInit = {}) => {
 
 export const fetchFromApi =
   (apiServer: string) =>
-    async (path: string, opts = {}) => {
-      return fetcher(withApiServer(apiServer)(path), {
-        ...opts,
-      });
-    };
+  async (path: string, opts = {}) => {
+    return fetcher(withApiServer(apiServer)(path), {
+      ...opts,
+    });
+  };

--- a/src/common/api/fetch.ts
+++ b/src/common/api/fetch.ts
@@ -1,18 +1,22 @@
 import { HIRO_HEADERS, withApiServer } from '@/common/constants';
 
-export const fetcher = (input: RequestInfo, init: RequestInit = {}) => {
+export const fetcher = async (input: RequestInfo, init: RequestInit = {}) => {
   const initHeaders = init.headers || {};
-  return fetch(input, {
-    credentials: 'omit',
-    ...init,
-    headers: { ...initHeaders, ...HIRO_HEADERS },
-  });
+  try {
+    return await fetch(input, {
+      credentials: 'omit',
+      ...init,
+      headers: { ...initHeaders, ...HIRO_HEADERS },
+    });
+  } catch (error) {
+    throw new Error(`Network error: ${error.message}`);
+  }
 };
 
 export const fetchFromApi =
   (apiServer: string) =>
-  async (path: string, opts = {}) => {
-    return fetcher(withApiServer(apiServer)(path), {
-      ...opts,
-    });
-  };
+    async (path: string, opts = {}) => {
+      return fetcher(withApiServer(apiServer)(path), {
+        ...opts,
+      });
+    };


### PR DESCRIPTION
closes https://github.com/hirosystems/explorer/issues/1154

Handled fetcher function gracefully

Previous code: 
<img width="694" alt="Screenshot 2023-05-30 at 11 24 55 PM" src="https://github.com/hirosystems/explorer/assets/29030948/a4c4c467-d980-4109-b6f6-dfd4ca74bb74">

Modified code: 
<img width="633" alt="Screenshot 2023-05-30 at 11 35 51 PM" src="https://github.com/hirosystems/explorer/assets/29030948/303859af-a4d5-4b75-b7bb-3512f7b151fe">


Files changed
`src/common/api/fetch.ts`