### PR TITLE
Documentation Mismatch | PNPM usage

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -27,11 +27,11 @@
 #       - uses: actions/setup-node@v2
 #         with:
 #           node-version: '18.9.0'
-#       - run: yarn install
+#       - run: pnpm install
 #       - run: npx playwright install --with-deps
 #       - name: Run tests
 #         run: |
 #           xvfb-run --auto-servernum -- \
-#             yarn run test:e2e
+#             pnpm run test:e2e
 #         env:
 #           PLAYWRIGHT_TEST_BASE_URL: ${{ steps.vercel_action.outputs.preview-url }}

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -13,7 +13,7 @@ To run the explorer locally, you must first clone the [Explorer repository](http
 You must also enusre you have installed the project dependencies listed below.
 
 - [NodeJS](https://nodejs.dev/en/) that includes `npm`
-- [Yarn](https://yarnpkg.com/)
+- [PNPM](https://pnpm.io/installation/)
 
 It is also highly recommended you install [Homebrew](https://brew.sh/).
 
@@ -22,18 +22,20 @@ It is also highly recommended you install [Homebrew](https://brew.sh/).
 To install project dependencies:
 
 1. Open your terminal window and make sure you are in the `/explorer` folder.
-2. Run the `yarn` command to install the project dependencies.
+2. Run the `pnpm i` command to install the project dependencies.
 
 ## Setting Environment Variables
 
 The Explorer application needs the environment variables listed below to work properly. 
 
-- NEXT_PUBLIC_MAINNET_API_SERVER=https://api.hiro.so
-- NEXT_PUBLIC_TESTNET_API_SERVER=https://api.testnet.hiro.so
-- NEXT_PUBLIC_LEGACY_EXPLORER_API_SERVER=https://explorer-api.legacy.blockstack.org
-- NEXT_PUBLIC_DEPLOYMENT_URL=https://explorer.hiro.so
-- NEXT_PUBLIC_MAINNET_ENABLED="true"
-- NEXT_PUBLIC_DEFAULT_POLLING_INTERVAL="10000"
+```
+NEXT_PUBLIC_MAINNET_API_SERVER=https://api.hiro.so
+NEXT_PUBLIC_TESTNET_API_SERVER=https://api.testnet.hiro.so
+NEXT_PUBLIC_LEGACY_EXPLORER_API_SERVER=https://explorer-api.legacy.blockstack.org
+NEXT_PUBLIC_DEPLOYMENT_URL=https://explorer.hiro.so
+NEXT_PUBLIC_MAINNET_ENABLED="true"
+NEXT_PUBLIC_DEFAULT_POLLING_INTERVAL="10000"
+```
 
 > **_NOTE:_**
 >

--- a/docs/how-to-guides/build-explorer.md
+++ b/docs/how-to-guides/build-explorer.md
@@ -4,16 +4,16 @@ Title: Build Explorer
 
 # Build Explorer
 
-After installing and configuring your environment, you can run Explorer locally if you wish by running the followning `yarn` command:
+After installing and configuring your environment, you can run Explorer locally if you wish by running the followning `pnpm` command:
 
-`yarn dev`
+`pnpm dev`
 
 ## Building for Production
 
 You may also build a production version of Explorer. Simply run the following command:
 
-`yarn build`
+`pnpm build`
 
 > **_NOTE:_**
 >
-> Running `yarn build` also run the default next.js build task.
+> Running `pnpm build` also run the default next.js build task.

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -13,13 +13,13 @@ Before you can run Explorer on your machine locally, you must first clone the [E
 Once you have cloned the Explorer repositories, you will need to install the following project dependencies:
 
 - [NodeJS](https://nodejs.dev/en/) that includes `npm`
-- [Yarn](https://yarnpkg.com/)
+- [PNPM](https://pnpm.io/installation/)
 - [Homebrew](https://brew.sh/)
 
 > **_NOTE:_**
 >
 > Although Homebrew is not required to install and operate Explorer, it is highly recommended.
 
-Open your terminal window, and make sure you are in the `/explorer` folder. Run the `yarn` to install the dependencies:
+Open your terminal window, and make sure you are in the `/explorer` folder. Run the below command to install the dependencies:
 
-`yarn`
+`pnpm i`

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "build": "next telemetry disable && next build",
     "build:analyze": "next telemetry disable && ANALYZE=true next build",
     "dev": "next dev",
-    "lint": "yarn run lint:eslint && yarn run lint:prettier",
+    "lint": "pnpm run lint:eslint && pnpm run lint:prettier",
     "lint:eslint": "eslint --ext .ts,.tsx ./src",
     "lint:fix": "eslint --ext .ts,.tsx ./src/ -f unix --fix && prettier --write src/**/*.{ts,tsx} *.js",
     "lint:prettier": "prettier --check \"src/**/*.{ts,tsx}\" *.js *.json",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -67,7 +67,7 @@ if (!process.env.PLAYWRIGHT_TEST_BASE_URL) {
   // Run your local dev server before starting the tests:
   // https://playwright.dev/docs/test-advanced#launching-a-development-web-server-during-the-tests
   config.webServer = {
-    command: 'yarn dev',
+    command: 'pnpm dev',
     port: 3000,
     timeout: 120 * 1000,
     reuseExistingServer: !process.env.CI,


### PR DESCRIPTION
Issues:
1. In this repository, the use of Pnpm for installing dependencies is mandatory. It would be beneficial to remove other package managers and prioritize Pnpm instead.
2. The readme.md file contains the correct steps, but the files within the docs folder have not been updated.
4. The hirosystem/docs repository retrieves content from the outdated docs folder. Please refer to the attached image.
<br><br>
Changes:
1. [X] Updated all md files under docs folder
2. [X] All yarn commands have been replaced with Pnpm commands.
6. [X] I have verified, Application runs locally after the changes by running `pnpm dev`
<br><br>
Image - Code snippet - `hirosystem/docs`
<br>

![Explorer Doc](https://github.com/hirosystems/explorer/assets/14936826/e208497b-4110-4a07-835a-f1cd2ad84227)


cc @andresgalante 