### PR TITLE
fix: StxPriceButton click gives 'NaN' on historical data

### DIFF
--- a/src/app/common/components/StxPriceButton/index.tsx
+++ b/src/app/common/components/StxPriceButton/index.tsx
@@ -25,7 +25,9 @@ export const StxPriceButton: FC<StxPriceButtonProps> = ({ tx, value }) => {
   const [initialRender, setInitialRender] = useState(true);
   const toggleStxPrice = useCallback(() => {
     if (initialRender) setInitialRender(false);
-    historicalStxPrice && setTooltipContentIndex((tooltipContentIndex + 1) % tooltipContent.length);
+    if (historicalStxPrice !== undefined) {
+      setTooltipContentIndex((tooltipContentIndex + 1) % tooltipContent.length);
+    }
   }, [initialRender, tooltipContentIndex, historicalStxPrice]);
   const showCurrentPriceForCompletedTransactions = tooltipContentIndex !== 1;
   const currentPriceFormatted = useMemo(

--- a/src/app/common/components/StxPriceButton/index.tsx
+++ b/src/app/common/components/StxPriceButton/index.tsx
@@ -25,8 +25,8 @@ export const StxPriceButton: FC<StxPriceButtonProps> = ({ tx, value }) => {
   const [initialRender, setInitialRender] = useState(true);
   const toggleStxPrice = useCallback(() => {
     if (initialRender) setInitialRender(false);
-    setTooltipContentIndex((tooltipContentIndex + 1) % tooltipContent.length);
-  }, [initialRender, tooltipContentIndex]);
+    historicalStxPrice && setTooltipContentIndex((tooltipContentIndex + 1) % tooltipContent.length);
+  }, [initialRender, tooltipContentIndex, historicalStxPrice]);
   const showCurrentPriceForCompletedTransactions = tooltipContentIndex !== 1;
   const currentPriceFormatted = useMemo(
     () => getUsdValue(value, currentStxPrice, true),


### PR DESCRIPTION
closes #1125

Feature details
When Coingecko's API limit is exceeded, it results in an undefined value. In such cases, if the historicalData is undefined, we refrain from displaying the historical data (USD value) on the frontend.

Files changed
src/app/common/components/StxPriceButton/index.tsx