### PR TITLE
feat: show receipt time on transaction page

### DIFF
--- a/src/app/components/BlockList/__tests__/__snapshots__/MicroblockListItem.test.tsx.snap
+++ b/src/app/components/BlockList/__tests__/__snapshots__/MicroblockListItem.test.tsx.snap
@@ -3,10 +3,10 @@
 exports[`MicroblockListItem component renders correctly 1`] = `
 <DocumentFragment>
   <div
-    class="css-brzhns"
+    class="css-r9yb24"
   >
     <span
-      class="chakra-stack css-1h7m9p5"
+      class="chakra-stack css-mx5gzi"
     >
       <div
         class="css-1gqk193"
@@ -30,10 +30,10 @@ exports[`MicroblockListItem component renders correctly 1`] = `
         </svg>
       </div>
       <span
-        class="chakra-stack css-x6ucgl"
+        class="chakra-stack css-ueng8y"
       >
         <div
-          class="css-1exw3s2"
+          class="css-20iiw3"
         >
           <a
             class="chakra-text css-jqqks0"
@@ -51,7 +51,7 @@ exports[`MicroblockListItem component renders correctly 1`] = `
       </span>
     </span>
     <span
-      class="chakra-stack css-afdpdg"
+      class="chakra-stack css-tprkve"
     >
       <span
         class="chakra-text css-zousv3"

--- a/src/app/components/NavBar/__tests__/__snapshots__/DesktopNav.test.tsx.snap
+++ b/src/app/components/NavBar/__tests__/__snapshots__/DesktopNav.test.tsx.snap
@@ -3,16 +3,16 @@
 exports[`DesktopNav should render correctly 1`] = `
 <DocumentFragment>
   <div
-    class="chakra-stack css-1yubk4m"
+    class="chakra-stack css-1o2h1ld"
   >
     <div
-      class="css-1txr7ua"
+      class="css-15159ky"
     >
       <div
         aria-controls="popover-content-:r1:"
         aria-expanded="false"
         aria-haspopup="dialog"
-        class="css-1dz1cl"
+        class="css-1dc63cv"
         id="popover-trigger-:r1:"
       >
         <a
@@ -52,13 +52,13 @@ exports[`DesktopNav should render correctly 1`] = `
       </div>
     </div>
     <div
-      class="css-1txr7ua"
+      class="css-15159ky"
     >
       <div
         aria-controls="popover-content-:r3:"
         aria-expanded="false"
         aria-haspopup="dialog"
-        class="css-1dz1cl"
+        class="css-1dc63cv"
         id="popover-trigger-:r3:"
       >
         <a

--- a/src/app/components/NavBar/__tests__/__snapshots__/MobileNav.test.tsx.snap
+++ b/src/app/components/NavBar/__tests__/__snapshots__/MobileNav.test.tsx.snap
@@ -3,10 +3,10 @@
 exports[`MobileNav should render correctly 1`] = `
 <DocumentFragment>
   <div
-    class="chakra-stack css-4xpai1"
+    class="chakra-stack css-j054pp"
   >
     <div
-      class="css-sw0q0z"
+      class="css-hwh8lq"
     >
       <button
         aria-label="Change color mode"
@@ -27,13 +27,17 @@ exports[`MobileNav should render correctly 1`] = `
           width="1em"
           xmlns="http://www.w3.org/2000/svg"
         >
+          <desc />
           <path
             d="M0 0h24v24H0z"
             fill="none"
             stroke="none"
           />
-          <path
-            d="M3 3l18 18"
+          <line
+            x1="3"
+            x2="21"
+            y1="3"
+            y2="21"
           />
           <path
             d="M16 12a4 4 0 0 0 -4 -4m-2.834 1.177a4 4 0 0 0 5.66 5.654"
@@ -61,16 +65,23 @@ exports[`MobileNav should render correctly 1`] = `
           width="32px"
           xmlns="http://www.w3.org/2000/svg"
         >
+          <desc />
           <path
             d="M0 0h24v24H0z"
             fill="none"
             stroke="none"
           />
-          <path
-            d="M18 6l-12 12"
+          <line
+            x1="18"
+            x2="6"
+            y1="6"
+            y2="18"
           />
-          <path
-            d="M6 6l12 12"
+          <line
+            x1="6"
+            x2="18"
+            y1="6"
+            y2="18"
           />
         </svg>
       </button>
@@ -79,10 +90,10 @@ exports[`MobileNav should render correctly 1`] = `
       class="css-xar605"
     >
       <div
-        class="chakra-stack css-bi0nzx"
+        class="chakra-stack css-1bf3tp6"
       >
         <a
-          class="css-3xyie7"
+          class="css-loh7ac"
           href="#"
         >
           <span
@@ -91,7 +102,7 @@ exports[`MobileNav should render correctly 1`] = `
             Mobile Sample Item 1
           </span>
           <svg
-            class="chakra-icon css-3tv48m"
+            class="chakra-icon css-1uilshh"
             fill="currentColor"
             focusable="false"
             height="1em"
@@ -112,7 +123,7 @@ exports[`MobileNav should render correctly 1`] = `
           style="overflow: hidden; display: none; opacity: 0; height: 0px;"
         >
           <div
-            class="chakra-stack css-k96o6u"
+            class="chakra-stack css-sgwtyh"
           >
             <a
               class="css-9sazr8"
@@ -124,10 +135,10 @@ exports[`MobileNav should render correctly 1`] = `
         </div>
       </div>
       <div
-        class="chakra-stack css-bi0nzx"
+        class="chakra-stack css-1bf3tp6"
       >
         <a
-          class="css-3xyie7"
+          class="css-loh7ac"
           href="#"
         >
           <span
@@ -141,7 +152,7 @@ exports[`MobileNav should render correctly 1`] = `
           style="overflow: hidden; display: none; opacity: 0; height: 0px;"
         >
           <div
-            class="chakra-stack css-k96o6u"
+            class="chakra-stack css-sgwtyh"
           />
         </div>
       </div>

--- a/src/app/txid/[txid]/ContractCall/TxDetails.tsx
+++ b/src/app/txid/[txid]/ContractCall/TxDetails.tsx
@@ -11,7 +11,7 @@ import {
 import { useVerticallyStackedElementsBorderStyle } from '../../../common/styles/border';
 import { BlockHash } from '../TxDetails/BlockHash';
 import { BlockHeight } from '../TxDetails/BlockHeight';
-import { Broadcasted } from '../TxDetails/Broadcasted';
+import { Broadcast } from '../TxDetails/Broadcast';
 import { ContractName } from '../TxDetails/ContractName';
 import { Fees } from '../TxDetails/Fees';
 import { ID } from '../TxDetails/ID';
@@ -36,7 +36,7 @@ export const TxDetails: React.FC<TxDetailsProps> = ({ tx, block }) => {
             <Fees tx={tx} />
             <Nonce tx={tx} />
             <BlockHeight tx={tx} block={block} />
-            <Broadcasted tx={tx} />
+            <Broadcast tx={tx} />
             <BlockHash tx={tx} />
             <NonCanonical tx={tx} />
           </Box>

--- a/src/app/txid/[txid]/ContractCall/TxDetails.tsx
+++ b/src/app/txid/[txid]/ContractCall/TxDetails.tsx
@@ -11,6 +11,7 @@ import {
 import { useVerticallyStackedElementsBorderStyle } from '../../../common/styles/border';
 import { BlockHash } from '../TxDetails/BlockHash';
 import { BlockHeight } from '../TxDetails/BlockHeight';
+import { Broadcasted } from '../TxDetails/Broadcasted';
 import { ContractName } from '../TxDetails/ContractName';
 import { Fees } from '../TxDetails/Fees';
 import { ID } from '../TxDetails/ID';
@@ -35,6 +36,7 @@ export const TxDetails: React.FC<TxDetailsProps> = ({ tx, block }) => {
             <Fees tx={tx} />
             <Nonce tx={tx} />
             <BlockHeight tx={tx} block={block} />
+            <Broadcasted tx={tx} />
             <BlockHash tx={tx} />
             <NonCanonical tx={tx} />
           </Box>

--- a/src/app/txid/[txid]/TxDetails/Broadcast.tsx
+++ b/src/app/txid/[txid]/TxDetails/Broadcast.tsx
@@ -10,10 +10,9 @@ import { KeyValueHorizontal } from '../../../common/components/KeyValueHorizonta
 import { Value } from '../../../common/components/Value';
 import { isInMempool } from '../utils';
 
-export const Broadcasted: FC<{
+export const Broadcast: FC<{
   tx: Transaction | MempoolTransaction;
 }> = ({ tx }) => {
-
   if (!isInMempool(tx)) return null;
 
   const ts = tx.receipt_time;
@@ -25,7 +24,7 @@ export const Broadcasted: FC<{
 
   return (
     <KeyValueHorizontal
-      label={'Broadcasted'}
+      label={'Broadcast'}
       value={
         <>
           <Box>

--- a/src/app/txid/[txid]/TxDetails/Broadcasted.tsx
+++ b/src/app/txid/[txid]/TxDetails/Broadcasted.tsx
@@ -1,0 +1,44 @@
+import { toRelativeTime } from '@/common/utils';
+import { Box, Flex, Icon, Tooltip } from '@/ui/components';
+import * as React from 'react';
+import { FC } from 'react';
+import { AiOutlineClockCircle } from 'react-icons/ai';
+
+import { Transaction, MempoolTransaction } from '@stacks/stacks-blockchain-api-types';
+
+import { KeyValueHorizontal } from '../../../common/components/KeyValueHorizontal';
+import { Value } from '../../../common/components/Value';
+import { isInMempool } from '../utils';
+
+export const Broadcasted: FC<{
+  tx: Transaction | MempoolTransaction;
+}> = ({ tx }) => {
+
+  if (!isInMempool(tx)) return null;
+
+  const ts = tx.receipt_time;
+  if (!ts) return null;
+
+  const readableTs = `${new Date(ts * 1000).toLocaleTimeString()} ${new Date(
+    ts * 1000
+  ).toLocaleDateString()}`;
+
+  return (
+    <KeyValueHorizontal
+      label={'Broadcasted'}
+      value={
+        <>
+          <Box>
+            <Tooltip label={readableTs}>
+              <Flex alignItems="center">
+                <Icon as={AiOutlineClockCircle} size="16px" mr="4px" />
+                <Value>{toRelativeTime(ts * 1000)}</Value>
+              </Flex>
+            </Tooltip>
+          </Box>
+        </>
+      }
+      copyValue={readableTs}
+    />
+  );
+};

--- a/src/app/txid/[txid]/TxDetails/__tests__/Broadcast.test.tsx
+++ b/src/app/txid/[txid]/TxDetails/__tests__/Broadcast.test.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { Broadcast } from '../Broadcast';
+import '@testing-library/jest-dom/extend-expect';
+import {Transaction} from "@stacks/stacks-blockchain-api-types";
+
+describe('<Broadcast />', () => {
+  it('renders correctly', () => {
+    const hardcodedDate = new Date('2023-01-01T12:00:00Z');
+
+    const mockTx = {
+      receipt_time: Math.floor(hardcodedDate.getTime() / 1000)
+    } as unknown as Transaction;
+
+    const { asFragment } = render(<Broadcast tx={mockTx} />);
+    expect(asFragment()).toMatchSnapshot();
+  });
+});

--- a/src/app/txid/[txid]/TxDetails/__tests__/__snapshots__/Broadcast.test.tsx.snap
+++ b/src/app/txid/[txid]/TxDetails/__tests__/__snapshots__/Broadcast.test.tsx.snap
@@ -1,0 +1,72 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<Broadcast /> renders correctly 1`] = `
+<DocumentFragment>
+  <div
+    class="css-1pxgzpz"
+  >
+    <div
+      class="css-14yezot"
+    >
+      Broadcast
+    </div>
+    <div
+      class="css-15u2v2k"
+    >
+      <div
+        class="css-1dupj0l"
+      >
+        <div
+          class="css-15159ky"
+        >
+          <svg
+            class="chakra-icon css-1p0vfbv"
+            fill="currentColor"
+            focusable="false"
+            height="16px"
+            stroke="currentColor"
+            stroke-width="0"
+            viewBox="0 0 1024 1024"
+            width="16px"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm0 820c-205.4 0-372-166.6-372-372s166.6-372 372-372 372 166.6 372 372-166.6 372-372 372z"
+            />
+            <path
+              d="M686.7 638.6L544.1 535.5V288c0-4.4-3.6-8-8-8H488c-4.4 0-8 3.6-8 8v275.4c0 2.6 1.2 5 3.3 6.5l165.4 120.6c3.6 2.6 8.6 1.8 11.2-1.7l28.6-39c2.6-3.7 1.8-8.7-1.8-11.2z"
+            />
+          </svg>
+          <span
+            class="chakra-text css-14nx52v"
+          >
+            9 months ago
+          </span>
+        </div>
+      </div>
+    </div>
+    <button
+      aria-label="copy row"
+      class="chakra-button fancy-copy css-13ha820"
+      type="button"
+    >
+      <svg
+        aria-hidden="true"
+        color="textBody"
+        fill="currentColor"
+        focusable="false"
+        height="20px"
+        stroke="currentColor"
+        stroke-width="1.75"
+        viewBox="0 0 1024 1024"
+        width="20px"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M832 64H296c-4.4 0-8 3.6-8 8v56c0 4.4 3.6 8 8 8h496v688c0 4.4 3.6 8 8 8h56c4.4 0 8-3.6 8-8V96c0-17.7-14.3-32-32-32zM704 192H192c-17.7 0-32 14.3-32 32v530.7c0 8.5 3.4 16.6 9.4 22.6l173.3 173.3c2.2 2.2 4.7 4 7.4 5.5v1.9h4.2c3.5 1.3 7.2 2 11 2H704c17.7 0 32-14.3 32-32V224c0-17.7-14.3-32-32-32zM350 856.2L263.9 770H350v86.2zM664 888H414V746c0-22.1-17.9-40-40-40H232V264h432v624z"
+        />
+      </svg>
+    </button>
+  </div>
+</DocumentFragment>
+`;


### PR DESCRIPTION
Close [#1030](https://github.com/hirosystems/explorer/issues/1030)

On the transaction details page, for pending transactions (mempool), I added a new component for receipt time labeled "Broadcasted"

<img width="691" alt="Capture d'écran 2023-07-07 233318" src="https://github.com/hirosystems/explorer/assets/12425932/fc296a8c-9386-4592-b791-1eb809efcc3e">
