### PR TITLE
fix: holdings indicator incosistent

### DIFF
--- a/src/common/utils/accounts.ts
+++ b/src/common/utils/accounts.ts
@@ -10,8 +10,9 @@ export const hasTokenBalance = (balances?: AddressBalanceResponse) => {
   let totalFt = 0;
   let totalNft = 0;
   if (balances?.fungible_tokens) {
-    totalFt =
-      (balances.fungible_tokens && Object.keys(balances?.fungible_tokens || {}).length) || 0;
+    Object.keys(balances?.fungible_tokens || {}).forEach(key => {
+      totalFt += parseInt(balances?.fungible_tokens?.[key]?.balance || '0');
+    });
   }
   if (balances.non_fungible_tokens) {
     totalNft = Object.keys(balances?.non_fungible_tokens || {}).length;

--- a/src/components/balances/principal-token-balances.tsx
+++ b/src/components/balances/principal-token-balances.tsx
@@ -43,10 +43,14 @@ export const NftBalances: React.FC<{
   );
 };
 
-export const FtBalances: React.FC<{ balances: AddressBalanceResponse }> = ({ balances }) =>
-  Object.keys(balances.fungible_tokens).length ? (
+export const FtBalances: React.FC<{ balances: AddressBalanceResponse }> = ({ balances }) => {
+  const FTokens = Object.keys(balances.fungible_tokens).filter(
+    key => Number(balances.fungible_tokens[key]?.balance) > 0
+  );
+
+  return FTokens.length ? (
     <>
-      {Object.keys(balances.fungible_tokens).map((key, index, arr) => (
+      {FTokens?.map((key, index, arr) => (
         <TokenAssetListItem
           amount={balances.fungible_tokens[key]?.balance || ''}
           key={index}
@@ -60,6 +64,7 @@ export const FtBalances: React.FC<{ balances: AddressBalanceResponse }> = ({ bal
       <Caption>This account has no tokens.</Caption>
     </Grid>
   );
+};
 
 export const TokenBalancesCard: React.FC<
   FlexProps & { balances: AddressBalanceResponse; nftHoldings?: NonFungibleTokenHoldingsList }

--- a/src/components/balances/token-balances-row.tsx
+++ b/src/components/balances/token-balances-row.tsx
@@ -7,10 +7,14 @@ import { AddressBalanceResponse } from '@stacks/stacks-blockchain-api-types';
 interface TokenBalancesRowProps extends StackProps {
   balances?: AddressBalanceResponse;
 }
+
 export const TokenBalancesRow: React.FC<TokenBalancesRowProps> = ({ balances }) => {
+  const FTokens = Object.keys(balances?.fungible_tokens ?? {}).filter(
+    key => Number(balances?.fungible_tokens?.[key]?.balance) > 0
+  );
   return (
     <Stack isInline spacing={'16px'}>
-      <NumberedBadge array={Object.keys(balances?.fungible_tokens || [])} singular="token" />
+      <NumberedBadge array={FTokens} singular="token" />
       <NumberedBadge
         array={Object.keys(balances?.non_fungible_tokens || [])}
         singular="collectible"


### PR DESCRIPTION
This PR closes #1235 

Holdings indicator in both left and right panels are consistent now.
![image](https://github.com/hirosystems/explorer/assets/67862382/39cad8aa-7fbd-480f-b497-808c8ff186d0)
