### PR TITLE
feat: add custom network using query param

### DIFF
--- a/src/common/context/__tests__/GlobalContext.test.tsx
+++ b/src/common/context/__tests__/GlobalContext.test.tsx
@@ -1,0 +1,64 @@
+import { useContext } from 'react';
+import { AppContextProvider, GlobalContext } from '../GlobalContext';
+import { render, screen, waitFor } from '@testing-library/react';
+import { fetchCustomNetworkId } from '@/components/add-network-form';
+
+jest.mock('@/components/add-network-form', () => ({
+  ...jest.requireActual('@/components/add-network-form'),
+  fetchCustomNetworkId: jest.fn(() => '1111'),
+}));
+
+const GlobalContextTestComponent = () => {
+  const { activeNetwork, networks } = useContext(GlobalContext);
+  return (
+    <div>
+      <div>Global Context Test</div>
+      <div data-testid="activeNetwork">{JSON.stringify(activeNetwork)}</div>
+      <div data-testid="networks">{JSON.stringify(networks)}</div>
+    </div>
+  );
+};
+
+const apiUrls = {
+  mainnet: 'https://api.hiro.so',
+  testnet: 'https://api.testnet.hiro.so',
+};
+
+const getContextField = (fieldId: string) => {
+  return JSON.parse(screen.getByTestId(fieldId).innerHTML);
+};
+
+describe('GlobalContext', () => {
+  it('renders provider and children without error', () => {
+    render(
+      <AppContextProvider apiUrls={apiUrls}>
+        <GlobalContextTestComponent />
+      </AppContextProvider>
+    );
+
+    expect(screen.getByText('Global Context Test')).toBeInTheDocument();
+  });
+
+  it('adds a custom network from a query string', async () => {
+    const customApiUrl = 'https://my-custom-api-url.com/something';
+
+    render(
+      <AppContextProvider apiUrls={apiUrls} queryApiUrl={customApiUrl}>
+        <GlobalContextTestComponent />
+      </AppContextProvider>
+    );
+
+    const networks = getContextField('networks');
+    expect(Object.keys(networks).length).toBe(3);
+
+    await waitFor(() => {
+      expect(fetchCustomNetworkId).toHaveBeenCalledWith(customApiUrl, false);
+    });
+
+    await waitFor(() => {
+      const updatedNetworks = getContextField('networks');
+      expect(Object.keys(updatedNetworks).length).toBe(4);
+      expect(updatedNetworks[customApiUrl].isCustomNetwork).toBe(true);
+    });
+  });
+});

--- a/src/components/__tests__/add-network-form.test.tsx
+++ b/src/components/__tests__/add-network-form.test.tsx
@@ -1,0 +1,32 @@
+import { buildCustomNetworkUrl } from '../add-network-form';
+
+describe('buildCustomNetworkUrl', () => {
+  const cases = [
+    {
+      description: 'builds URL',
+      url: 'https://some-custom-url.com',
+      expectedOutput: 'https://some-custom-url.com',
+    },
+    {
+      description: 'builds URL with port',
+      url: 'https://some-custom-url.com:1234',
+      expectedOutput: 'https://some-custom-url.com:1234',
+    },
+    {
+      description: 'builds URL for localhost',
+      url: 'http://localhost:1234',
+      expectedOutput: 'http://localhost:1234',
+    },
+    {
+      description: 'builds URL with path',
+      url: 'https://some-custom-url.com/some/path',
+      expectedOutput: 'https://some-custom-url.com/some/path',
+    },
+  ];
+
+  cases.forEach(({ description, url, expectedOutput }) => {
+    it(description, () => {
+      expect(buildCustomNetworkUrl(url)).toEqual(expectedOutput);
+    });
+  });
+});

--- a/src/components/add-network-form.tsx
+++ b/src/components/add-network-form.tsx
@@ -22,16 +22,20 @@ import { string } from 'yup';
 
 import { ChainID } from '@stacks/transactions';
 
-const buildCustomNetworkUrl = (url: string) => {
-  const hostname = encodeURIComponent(new URL(url).hostname);
-  const port = encodeURIComponent(new URL(url).port);
-  return `${hostname === 'localhost' ? 'http://' : 'https://'}${hostname}${port ? `:${port}` : ''}`;
+export const buildCustomNetworkUrl = (url: string) => {
+  const urlObj = new URL(url);
+  const hostname = encodeURIComponent(urlObj.hostname);
+  const port = encodeURIComponent(urlObj.port);
+  const pathname = !urlObj?.pathname || urlObj.pathname === '/' ? '' : urlObj.pathname;
+  return `${hostname === 'localhost' ? 'http://' : 'https://'}${hostname}${port ? `:${port}` : ''}${
+    pathname || ''
+  }`;
 };
 
-const fetchCustomNetworkId: (url: string, isSubnet: boolean) => Promise<ChainID | undefined> = (
-  url,
-  isSubnet
-) => {
+export const fetchCustomNetworkId: (
+  url: string,
+  isSubnet: boolean
+) => Promise<ChainID | undefined> = (url, isSubnet) => {
   return fetchFromApi(url)(DEFAULT_V2_INFO_ENDPOINT)
     .then(res => res.json())
     .then(res =>
@@ -136,7 +140,7 @@ export const AddNetworkForm: React.FC = () => {
               <Field name="url">
                 {({ field, form }: FieldProps<string, FormValues>) => (
                   <FormControl isInvalid={!!form.errors.url && !!form.touched.url}>
-                    <FormLabel>URL</FormLabel>
+                    <FormLabel>Base URL</FormLabel>
                     <Input {...field} placeholder="https://" />
                     <FormErrorMessage>{form.errors.url}</FormErrorMessage>
                   </FormControl>


### PR DESCRIPTION
When opening the Stacks Explorer with an API URL in the query string (`api`), if that network does not exist and it is a valid Stacks API URL, add it to the list of custom networks. This allows an external application to link to the Explorer with a prefilled custom Stacks network, and the Explorer will automatically open to that network.

Also, support custom networks whose Base URL includes a path (fixes #1257).