### PR TITLE
fix: read-only function call caching

### DIFF
--- a/src/app/sandbox/components/ContractCall/ReadOnlyField.tsx
+++ b/src/app/sandbox/components/ContractCall/ReadOnlyField.tsx
@@ -39,7 +39,11 @@ export const ReadOnlyField: FC<ReadOnlyProps> = ({
         network: stacksNetwork,
         senderAddress: stxAddress,
       }),
-    { suspense: false }
+    {
+      suspense: false,
+      staleTime: 0,
+      cacheTime: 0,
+    }
   );
 
   if (!data) return null;


### PR DESCRIPTION
Disabling react-query cache when calling read-only functions.
closes #1218 