### PR TITLE
fix: sandbox clarity examples syntax

### DIFF
--- a/src/common/contracts/hello-world-contract.tsx
+++ b/src/common/contracts/hello-world-contract.tsx
@@ -6,36 +6,50 @@ export const helloWorldContract = {
 (define-constant recipient 'SM2J6ZY48GV1EZ5V2V5RB9MP66SW86PYKKQVX8X0G)
 
 (define-fungible-token novel-token-19)
-(begin (ft-mint? novel-token-19 u12 sender))
-(begin (ft-transfer? novel-token-19 u2 sender recipient))
+(ft-mint? novel-token-19 u12 sender)
+(ft-transfer? novel-token-19 u2 sender recipient)
 
 (define-non-fungible-token hello-nft uint)
-(begin (nft-mint? hello-nft u1 sender))
-(begin (nft-mint? hello-nft u2 sender))
-(begin (nft-transfer? hello-nft u1 sender recipient))
+
+(nft-mint? hello-nft u1 sender)
+(nft-mint? hello-nft u2 sender)
+(nft-transfer? hello-nft u1 sender recipient)
 
 (define-public (test-emit-event)
-    (begin
-        (print "Event! Hello world")
-        (ok u1)))
+  (begin
+    (print "Event! Hello world"
+    (ok u1)
+  )
+)
+
 (begin (test-emit-event))
 
 (define-public (test-event-types)
-    (begin
-        (unwrap-panic (ft-mint? novel-token-19 u3 recipient))
-        (unwrap-panic (nft-mint? hello-nft u2 recipient))
-        (unwrap-panic (stx-transfer? u60 tx-sender 'SZ2J6ZY48GV1EZ5V2V5RB9MP66SW86PYKKQ9H6DPR))
-        (unwrap-panic (stx-burn? u20 tx-sender))
-        (ok u1)))
+  (begin
+    (unwrap-panic (ft-mint? novel-token-19 u3 recipient))
+    (unwrap-panic (nft-mint? hello-nft u2 recipient))
+    (unwrap-panic (stx-transfer? u60 tx-sender 'SZ2J6ZY48GV1EZ5V2V5RB9MP66SW86PYKKQ9H6DPR))
+    (unwrap-panic (stx-burn? u20 tx-sender))
+    (ok u1)
+  )
+)
 
-(define-map store {key: (buff 32)} {value: (buff 32)})
+(define-map store { key: (buff 32) } { value: (buff 32) })
+
 (define-public (get-value (key (buff 32)))
-    (begin
-        (match (map-get? store {key: key})
-            entry (ok (get value entry))
-            (err 0))))
+  (begin
+    (match (map-get? store { key: key })
+      entry (ok (get value entry))
+      (err 0)
+    )
+  )
+)
+
 (define-public (set-value (key (buff 32)) (value (buff 32)))
-    (begin
-        (map-set store {key: key} {value: value})
-        (ok u1)))`,
+  (begin
+    (map-set store { key: key } { value: value })
+    (ok u1)
+  )
+)
+`,
 };

--- a/src/common/contracts/kv-store.tsx
+++ b/src/common/contracts/kv-store.tsx
@@ -2,15 +2,20 @@ export const kvStoreContract = {
   name: 'kv-store',
   source: `;; kv-store contract
 
-(define-map store ((key (buff 32))) ((value (buff 32))))
+(define-map store { key: (buff 32) } { value: (buff 32) })
 
 (define-public (get-value (key (buff 32)))
-    (match (map-get? store {key: key})
-        entry (ok (get value entry))
-        (err 0)))
+  (match (map-get? store { key: key })
+    entry (ok (get value entry))
+    (err 0)
+  )
+)
 
 (define-public (set-value (key (buff 32)) (value (buff 32)))
-    (begin
-        (map-set store {key: key} {value: value})
-        (ok u1)))`,
+  (begin
+    (map-set store { key: key } { value: value })
+    (ok u1)
+  )
+)
+`,
 };

--- a/src/common/contracts/status.tsx
+++ b/src/common/contracts/status.tsx
@@ -3,34 +3,24 @@ export const statusContract = {
   source: `;; status contract
 
 (define-map statuses
-  (
-    (author principal)
-  )
-  (
-    (status (buff 512))
-  )
+  principal
+  { status: (buff 512) }
 )
 
 (define-read-only (get-status (author principal))
   (begin
     (print author)
-    (default-to ""
-      (get status (map-get? statuses {author: author}))
-    )
+    (default-to 0x (get status (map-get? statuses author)))
   )
 )
 
-(define-public (write-status!
-    (status (buff 512))
-  )
+(define-public (write-status (status (buff 512)))
   (begin
     (print tx-sender)
     (print status)
-    (map-set statuses
-      ((author tx-sender))
-      ((status status))
-    )
+    (map-set statuses tx-sender { status: status })
     (ok status)
   )
-)`,
+)
+`,
 };

--- a/src/common/contracts/stream.tsx
+++ b/src/common/contracts/stream.tsx
@@ -2,52 +2,35 @@ export const streamContract = {
   name: 'stream',
   source: `;; stream contract
 
-(define-public (say-hi)
-  (ok "hello world")
-)
-
-(define-public (echo-number (val int))
-  (ok val)
-)
-
-;; streams
+(define-constant ERR_STREAM_NOT_FOUND (err u1004))
 
 (define-map streams
-  ((id uint))
-  (
-    (start-block uint)
-    (recipient principal)
-    (sender principal)
-  )
+  uint
+  {
+    start-block: uint,
+    recipient: principal,
+    sender: principal,
+  }
 )
 
 (define-data-var next-stream-id uint u1)
 
-(define-public (make-stream
-    (recipient principal)
-  )
-  (begin
-    (map-set streams 
-      ((id (var-get next-stream-id)))
-      (
-        (start-block block-height)
-        (recipient recipient)
-        (sender tx-sender)
-      )
+(define-public (make-stream (recipient principal))
+  (let ((stream-id (var-get next-stream-id)))
+    (map-set streams
+      stream-id
+      {
+        start-block: block-height,
+        recipient: recipient,
+        sender: tx-sender,
+      }
     )
-    (var-set next-stream-id (+ (var-get next-stream-id) u1))
-    (ok 'true)
+    (ok (var-set next-stream-id (+ stream-id u1)))
   )
 )
 
-(define-public (get-stream
-    (stream-id uint)
-  )
-  (
-    ok
-    (unwrap-panic
-      (map-get? streams (tuple (id stream-id)))
-    )
-  )
-)`,
+(define-public (get-stream (stream-id uint))
+  (ok (unwrap! (map-get? streams stream-id) ERR_STREAM_NOT_FOUND))
+)
+`,
 };


### PR DESCRIPTION
Most of the contract examples in the explorer sandbox have a few syntax error. Especially on tuple definition (and sometimes unnecessary tuples).

I fixed the contract and made the coding style (lines breaks and indentation) more consistent over the examples