### PR TITLE
specified pnpm version

### DIFF
--- a/.github/workflows/code-check.yml
+++ b/.github/workflows/code-check.yml
@@ -21,7 +21,7 @@ jobs:
       - uses: actions/setup-node@v2
         with:
           node-version: '18.9.0'
-      - run: npm install -g pnpm
+      - run: npm install -g pnpm@8.9.1
       - run: pnpm i
       - name: Run unit tests
         run: pnpm run test --coverage

--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -130,7 +130,7 @@ jobs:
       - uses: actions/setup-node@v2
         with:
           node-version: '18.9.0'
-      - run: npm install -g pnpm
+      - run: npm install -g pnpm@8.9.1
       - run: pnpm i
       - run: npx playwright install --with-deps
       - name: Run tests

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -23,7 +23,7 @@ jobs:
         with:
           node-version: '18.9.0'
       - name: Install pnpm
-        run: npm install -g pnpm
+        run: npm install -g pnpm@8.9.1
       - name: Install Prettier
         run: pnpm add prettier@2.8.1
       - name: Lint Prettier

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ WORKDIR /app
 
 COPY . .
 
-RUN npm install -g pnpm
+RUN npm install -g pnpm@8.0.0
 RUN pnpm i
 RUN pnpm build
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ WORKDIR /app
 
 COPY . .
 
-RUN npm install -g pnpm@8.0.0
+RUN npm install -g pnpm@8.9.1
 RUN pnpm i
 RUN pnpm build
 


### PR DESCRIPTION
Suggested fix for issue 1323 - Docker build failing.

The build is breaking because of a new release of pnpm being incompatible. This should probably be fixed by understanding why the new release is breaking, but this should work for now.