### PR TITLE
fix: prevent iframe injection in another page

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -8,6 +8,19 @@ const nextConfig = {
       },
     ],
   },
+  async headers() {
+    return [
+      {
+        source: '/(.*)?', // Matches all pages
+        headers: [
+          {
+            key: 'X-Frame-Options',
+            value: 'DENY',
+          },
+        ],
+      },
+    ];
+  },
   async redirects() {
     return [
       {


### PR DESCRIPTION
This prevents the reuse of explorer.hiro.so inside an iframe.