### PR TITLE
fix(header-icons): fixed header icons

### DIFF
--- a/src/app/_components/BlockList/LayoutA/__tests__/__snapshots__/BlockListWithControls.test.tsx.snap
+++ b/src/app/_components/BlockList/LayoutA/__tests__/__snapshots__/BlockListWithControls.test.tsx.snap
@@ -209,7 +209,7 @@ exports[`BlockListWithControls renders correctly 1`] = `
                   <span
                     class="chakra-text css-nvxyq8"
                   >
-                    in 54066 years
+                    in 54071 years
                   </span>
                 </div>
               </div>
@@ -256,7 +256,7 @@ exports[`BlockListWithControls renders correctly 1`] = `
                   <span
                     class="chakra-text css-nvxyq8"
                   >
-                    in 54066 years
+                    in 54071 years
                   </span>
                 </div>
               </div>
@@ -303,7 +303,7 @@ exports[`BlockListWithControls renders correctly 1`] = `
                   <span
                     class="chakra-text css-nvxyq8"
                   >
-                    in 54066 years
+                    in 54071 years
                   </span>
                 </div>
               </div>
@@ -377,7 +377,7 @@ exports[`BlockListWithControls renders correctly 1`] = `
                 <span
                   class="chakra-text css-nvxyq8"
                 >
-                  in 54066 years
+                  in 54071 years
                 </span>
               </div>
             </div>

--- a/src/app/_components/NavBar/BtcStxPrice.tsx
+++ b/src/app/_components/NavBar/BtcStxPrice.tsx
@@ -31,13 +31,13 @@ function BtcStxPriceBase({ tokenPrice }: { tokenPrice: TokenPrice }) {
   const formattedStxPrice = tokenPrice.stxPrice ? usdFormatter.format(tokenPrice.stxPrice) : '';
   return (
     <Flex gap={6} minWidth={'172px'}>
-      <PriceContainer icon={<Icon as={BitcoinIcon} size={4.5} />} minWidth={'92px'}>
+      <PriceContainer icon={<Icon as={BitcoinIcon} size={'18px'} />} minWidth={'92px'}>
         {!formattedBtcPrice ? 'N/A' : formattedBtcPrice}
       </PriceContainer>
       <PriceContainer
         icon={
-          <Circle size={4.5} bg="brand" border={'none'}>
-            <Icon as={StxIcon} size={2.5} color="white" />
+          <Circle size={'18px'} bg="brand" border={'none'}>
+            <Icon as={StxIcon} size={'10px'} color="white" />
           </Circle>
         }
         minWidth={'56px'}


### PR DESCRIPTION
fixes header icon sizes

With components that are using circle and and grid, I have observed that the size property behaves inconsistently and doesn't correctly apply the chakra ui 1: 4rem scalling system. Therfore, I changed the numbers to hardcoded pixles. 