### PR TITLE
feat: add docker build for arm

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,6 +57,12 @@ jobs:
         with:
           ref: v${{ steps.semantic.outputs.new_release_version }}
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+      
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
       - name: Docker meta
         id: docker_meta
         uses: docker/metadata-action@v4
@@ -79,6 +85,7 @@ jobs:
         uses: docker/build-push-action@v3
         with:
           push: true
+          platforms: ${{ github.ref == 'refs/heads/main' && 'linux/amd64,linux/arm64' ||  'linux/amd64'  }}
           tags: ${{ steps.docker_meta.outputs.tags }}
           labels: ${{ steps.docker_meta.outputs.labels }}
           build-args: |


### PR DESCRIPTION
This pull requests add ARM builds to docker so one can host the explorer on an ARM server. The approach is to only do amd build on prs to not increase the build time and build both arm + amd on the main branch for the release.

Related: I added ARM support to the stacks-blockchain-api in this pr https://github.com/hirosystems/stacks-blockchain-api/pull/1947