### PR TITLE
fix(socket-errors): fixed

### DIFF
--- a/src/app/_components/BlockList/Sockets/use-stacks-api-socket-client.ts
+++ b/src/app/_components/BlockList/Sockets/use-stacks-api-socket-client.ts
@@ -4,52 +4,62 @@ import { StacksApiSocketClient } from '@stacks/blockchain-api-client';
 
 export interface StacksApiSocketClientInfo {
   client: StacksApiSocketClient | null;
-  connect: (handleOnConnect?: (client: StacksApiSocketClient) => void) => void;
+  connect: (
+    handleOnConnect?: (client: StacksApiSocketClient) => void,
+    handleError?: (client: StacksApiSocketClient | null) => void
+  ) => void;
   disconnect: () => void;
 }
 
 export function useStacksApiSocketClient(apiUrl: string): StacksApiSocketClientInfo {
   const [socketClient, setSocketClient] = useState<StacksApiSocketClient | null>(null);
-  const socketUrlTracker = useRef<string | null>(null);
   const isSocketClientConnecting = useRef(false);
 
+  const disconnect = useCallback(() => {
+    if (socketClient?.socket.connected) {
+      socketClient?.socket.removeAllListeners();
+      socketClient?.socket.close();
+      setSocketClient(null);
+    }
+  }, [socketClient]);
+
   const connect = useCallback(
-    async (handleOnConnect?: (client: StacksApiSocketClient) => void) => {
+    async (
+      handleOnConnect?: (client: StacksApiSocketClient) => void,
+      handleError?: (client: StacksApiSocketClient | null) => void
+    ) => {
       if (!apiUrl) return;
       if (socketClient?.socket.connected || isSocketClientConnecting.current) {
         return;
       }
       try {
         isSocketClientConnecting.current = true;
-        const socketUrl = apiUrl;
-        socketUrlTracker.current = socketUrl;
-        const client = await StacksApiSocketClient.connect({ url: socketUrl });
+        const client = await StacksApiSocketClient.connect({ url: apiUrl });
         client.socket.on('connect', () => {
           setSocketClient(client);
           handleOnConnect?.(client);
           isSocketClientConnecting.current = false;
         });
         client.socket.on('disconnect', () => {
-          setSocketClient(null);
+          client.socket.removeAllListeners();
+          client.socket.close();
+          disconnect();
           isSocketClientConnecting.current = false;
         });
         client.socket.on('connect_error', error => {
-          setSocketClient(null);
+          client.socket.removeAllListeners();
+          client.socket.close();
+          disconnect();
           isSocketClientConnecting.current = false;
+          handleError?.(client);
         });
       } catch (error) {
-        setSocketClient(null);
+        disconnect();
         isSocketClientConnecting.current = false;
       }
     },
-    [apiUrl, socketClient]
+    [apiUrl, socketClient, disconnect]
   );
-
-  const disconnect = useCallback(() => {
-    if (socketClient?.socket.connected) {
-      socketClient?.socket.close();
-    }
-  }, [socketClient]);
 
   return {
     client: socketClient,

--- a/src/app/_components/BlockList/Sockets/use-stacks-api-socket-client.ts
+++ b/src/app/_components/BlockList/Sockets/use-stacks-api-socket-client.ts
@@ -20,6 +20,7 @@ export function useStacksApiSocketClient(apiUrl: string): StacksApiSocketClientI
       socketClient?.socket.removeAllListeners();
       socketClient?.socket.close();
       setSocketClient(null);
+      isSocketClientConnecting.current = false;
     }
   }, [socketClient]);
 
@@ -38,24 +39,20 @@ export function useStacksApiSocketClient(apiUrl: string): StacksApiSocketClientI
         client.socket.on('connect', () => {
           setSocketClient(client);
           handleOnConnect?.(client);
-          isSocketClientConnecting.current = false;
         });
         client.socket.on('disconnect', () => {
           client.socket.removeAllListeners();
           client.socket.close();
           disconnect();
-          isSocketClientConnecting.current = false;
         });
         client.socket.on('connect_error', error => {
           client.socket.removeAllListeners();
           client.socket.close();
           disconnect();
-          isSocketClientConnecting.current = false;
           handleError?.(client);
         });
       } catch (error) {
         disconnect();
-        isSocketClientConnecting.current = false;
       }
     },
     [apiUrl, socketClient, disconnect]

--- a/src/app/_components/BlockList/Sockets/useSubscribeBlocks.ts
+++ b/src/app/_components/BlockList/Sockets/useSubscribeBlocks.ts
@@ -11,11 +11,12 @@ interface Subscription {
 
 export function useSubscribeBlocks(
   liveUpdates: boolean,
-  handleBlock: (block: NakamotoBlock | Block) => void
+  handleBlock: (block: NakamotoBlock | Block) => void,
+  handleError?: (client: StacksApiSocketClient | null) => void
 ) {
   const subscription = useRef<Subscription | undefined>(undefined);
   const { stacksApiSocketClientInfo } = useGlobalContext();
-  const { client, connect, disconnect } = stacksApiSocketClientInfo || {};
+  const { connect, disconnect } = stacksApiSocketClientInfo || {};
 
   useEffect(() => {
     const subscribe = async (client: StacksApiSocketClient) => {
@@ -28,15 +29,15 @@ export function useSubscribeBlocks(
       });
     };
 
-    if (liveUpdates && !client?.socket.connected) {
-      connect?.(client => subscribe(client));
+    if (liveUpdates) {
+      connect?.(client => subscribe(client), handleError);
     }
-    if (!liveUpdates && client?.socket.connected) {
+    if (!liveUpdates) {
       disconnect?.();
     }
     return () => {
       disconnect?.();
     };
-  }, [client, handleBlock, connect, liveUpdates, disconnect]);
+  }, [handleBlock, connect, liveUpdates, disconnect, handleError]);
   return subscription;
 }


### PR DESCRIPTION
I noticed a looping socket error on localhost on mainnet.

The socket hook is trying to use the client set in state to close the socket but the state client is not defined when an immediate connection error takes place, which leads to the disconnect code to never run. 
Now I am using the client var reference in the function to disconnect in addition to calling the disconnect code on the client in state if it exists

