### PR TITLE
feat: token price caching

### DIFF
--- a/src/app/getTokenPriceInfo.ts
+++ b/src/app/getTokenPriceInfo.ts
@@ -7,6 +7,7 @@ const TOKEN_PRICE_CACHE_KEY = 'token-price';
 
 export const getCurrentBtcPrice = async (): Promise<number> =>
   fetch('https://lunarcrush.com/api4/public/coins/btc/v1', {
+    next: { revalidate: 10 * 60 }, // Revalidate every 10
     headers: {
       Authorization: `Bearer ${LUNAR_CRUSH_API_KEY}`,
     },
@@ -16,6 +17,7 @@ export const getCurrentBtcPrice = async (): Promise<number> =>
 
 export const getCurrentStxPrice = async (): Promise<number> =>
   fetch('https://lunarcrush.com/api4/public/coins/stx/v1', {
+    next: { revalidate: 10 * 60 }, // Revalidate every 10
     headers: {
       Authorization: `Bearer ${LUNAR_CRUSH_API_KEY}`,
     },

--- a/src/app/stxPrice/route.ts
+++ b/src/app/stxPrice/route.ts
@@ -8,6 +8,7 @@ export async function GET(request: NextRequest) {
 
   if (!blockBurnTime || blockBurnTime === 'current') {
     const response = await fetch('https://lunarcrush.com/api4/public/coins/stx/v1', {
+      next: { revalidate: 10 * 60 }, // Revalidate every 10 minutes
       headers: {
         Authorization: `Bearer ${LUNAR_CRUSH_API_KEY}`,
       },


### PR DESCRIPTION
Add caching to token price requests with revalidation every 10 minutes. Cached request saves ~300ms of initial load.
Before:
<img width="1724" alt="Screenshot 2024-05-07 at 10 24 17 AM" src="https://github.com/hirosystems/explorer/assets/97111756/3f6cc607-cdef-408c-930e-570aa521e1ce">
After:
<img width="1713" alt="Screenshot 2024-05-07 at 10 25 09 AM" src="https://github.com/hirosystems/explorer/assets/97111756/273599c6-7947-4a0a-a600-e69fb49ad156">
