### PR TITLE
feat: network dropdown update

### DIFF
--- a/src/app/_components/NavBar/NetworkLabel.tsx
+++ b/src/app/_components/NavBar/NetworkLabel.tsx
@@ -78,7 +78,7 @@ export const NetworkLabel: FC<{ network: Network }> = ({ network }) => {
             <Badge bg={`bg4.${colorMode}`} ml="8px" color={`textCaption.${colorMode}`}>
               subnet
             </Badge>
-          ) : network.label === 'Stacks Testnet' ? (
+          ) : network.label === 'Stacks Testnet (Primary)' ? (
             <Badge
               color={greenBadgeColor}
               bg={greenBadgeBg}

--- a/src/app/_components/PageWrapper.tsx
+++ b/src/app/_components/PageWrapper.tsx
@@ -77,7 +77,7 @@ export function PageWrapper({
               <Text fontWeight={'bold'} display={'inline'}>
                 Testnet Update:
               </Text>{' '}
-              Primary Testnet is now Live and ready to use. More details{' '}
+              The Primary Stacks Testnet is reset and now live on Bitcoin Regtest. More details{' '}
               <TextLink
                 href="https://docs.stacks.co/nakamoto-upgrade/nakamoto-and-primary-testnet"
                 target="_blank"

--- a/src/common/context/GlobalContext.tsx
+++ b/src/common/context/GlobalContext.tsx
@@ -121,7 +121,7 @@ export const AppContextProvider: FC<{
         mode: NetworkModes.Mainnet,
       },
       [apiUrls[NetworkModes.Testnet]]: {
-        label: 'Stacks Testnet',
+        label: 'Stacks Testnet (Primary)',
         url: apiUrls[NetworkModes.Testnet],
         btcBlockBaseUrl: NetworkModeBtcBlockBaseUrlMap[NetworkModes.Testnet],
         btcTxBaseUrl: NetworkModeBtcTxBaseUrlMap[NetworkModes.Testnet],
@@ -129,9 +129,9 @@ export const AppContextProvider: FC<{
         networkId: ChainID.Testnet,
         mode: NetworkModes.Testnet,
       },
-      'https://api.old.testnet.hiro.so': {
-        label: 'Stacks Testnet (archive)',
-        url: 'https://api.old.testnet.hiro.so',
+      'https://api.nakamoto.testnet.hiro.so': {
+        label: 'Nakamoto Testnet',
+        url: 'https://api.nakamoto.testnet.hiro.so',
         btcBlockBaseUrl: NetworkModeBtcBlockBaseUrlMap[NetworkModes.Testnet],
         btcTxBaseUrl: NetworkModeBtcTxBaseUrlMap[NetworkModes.Testnet],
         btcAddressBaseUrl: NetworkModeBtcAddressBaseUrlMap[NetworkModes.Testnet],
@@ -139,9 +139,9 @@ export const AppContextProvider: FC<{
         mode: NetworkModes.Testnet,
         isCustomNetwork: true,
       },
-      'https://api.nakamoto.testnet.hiro.so': {
-        label: 'Nakamoto Testnet',
-        url: 'https://api.nakamoto.testnet.hiro.so',
+      'https://api.old.testnet.hiro.so': {
+        label: 'Stacks Testnet (Archive)',
+        url: 'https://api.old.testnet.hiro.so',
         btcBlockBaseUrl: NetworkModeBtcBlockBaseUrlMap[NetworkModes.Testnet],
         btcTxBaseUrl: NetworkModeBtcTxBaseUrlMap[NetworkModes.Testnet],
         btcAddressBaseUrl: NetworkModeBtcAddressBaseUrlMap[NetworkModes.Testnet],


### PR DESCRIPTION
- Change the banner text
- Rename "Stacks Testnet" to "Primary Stacks Testnet" on the network selection
- Move “Nakamoto Testnet” above “Stacks Testnet (archive)” in the dropdown