### PR TITLE
fix(orphan-blocks): added kv pair to show canonical status

### DIFF
--- a/src/app/block/[hash]/PageClient.tsx
+++ b/src/app/block/[hash]/PageClient.tsx
@@ -1,5 +1,7 @@
 'use client';
 
+import { Modal, ModalContent, ModalOverlay } from '@chakra-ui/react';
+import { Question, X } from '@phosphor-icons/react';
 import dynamic from 'next/dynamic';
 
 import { BtcStxBlockLinks } from '../../../common/components/BtcStxBlockLinks';
@@ -10,6 +12,12 @@ import { Value } from '../../../common/components/Value';
 import '../../../common/components/loaders/skeleton-text';
 import { useSuspenseBlockByHash } from '../../../common/queries/useBlockByHash';
 import { SkeletonTxsList } from '../../../features/txs-list/SkeletonTxsList';
+import { Box } from '../../../ui/Box';
+import { Flex } from '../../../ui/Flex';
+import { Icon } from '../../../ui/Icon';
+import { Stack } from '../../../ui/Stack';
+import { Text } from '../../../ui/Text';
+import { useDisclosure } from '../../../ui/hooks/useDisclosure';
 import { PageTitle } from '../../_components/PageTitle';
 import { TowColLayout } from '../../_components/TwoColLayout';
 import { BlockBtcAnchorBlockCard } from './BlockBtcAnchorBlockCard';
@@ -29,6 +37,8 @@ const BlockTxsList = dynamic(
 export default function BlockPage({ params: { hash } }: any) {
   const { data: block } = useSuspenseBlockByHash(hash, { refetchOnWindowFocus: true });
   const title = (block && `STX Block #${block.height.toLocaleString()}`) || '';
+  const { isOpen, onToggle, onClose } = useDisclosure();
+
   return (
     <>
       <PageTitle>{title}</PageTitle>
@@ -55,6 +65,56 @@ export default function BlockPage({ params: { hash } }: any) {
                 label={'Transactions'}
                 value={<Value>{block.txs.length}</Value>}
               />
+              {!block.canonical ? (
+                <KeyValueHorizontal
+                  label={'Canonical'}
+                  value={
+                    <Flex gap={2}>
+                      <Value>False</Value>
+                      <Icon as={Question} size={4} color="iconSubdued" onClick={onToggle} />
+                      <Modal isOpen={isOpen} onClose={onClose} isCentered>
+                        <ModalOverlay />
+                        <ModalContent>
+                          <Flex flexDirection="column" p={6} gap={4}>
+                            <Flex justifyContent="space-between">
+                              <Flex gap={2} alignItems="center">
+                                <Icon
+                                  as={Question}
+                                  size={6}
+                                  color="iconSubdued"
+                                  onClick={onToggle}
+                                />
+                                <Text fontSize={20} fontWeight="medium">
+                                  Non-Canonical Blocks
+                                </Text>
+                              </Flex>
+                              <Icon as={X} size={6} color="iconSubdued" onClick={onToggle} />
+                            </Flex>
+                            <Box>
+                              <Stack gap={5}>
+                                <Text lineHeight={5} fontSize={14}>
+                                  In the Bitcoin network, non-canonical blocks occur when two blocks
+                                  are mined simultaneously, causing a temporary split in the
+                                  blockchain. The BTC protocol follows the longest chain rule: so
+                                  whichever chain gains an additional block first becomes the
+                                  canonical chain. Miners switch to the longest chain, and the block
+                                  from the shorter chain is orphaned and excluded from the main
+                                  blockchain.
+                                </Text>
+                                <Text lineHeight={5} fontSize={14}>
+                                  On the Stacks blockchain, blocks mined on top of an orphaned BTC
+                                  block also become orphaned, and are discarded, as they are built
+                                  on a block that is not part of the Bitcoin main chain.
+                                </Text>
+                              </Stack>
+                            </Box>
+                          </Flex>
+                        </ModalContent>
+                      </Modal>
+                    </Flex>
+                  }
+                />
+              ) : null}
             </>
           )}
         </Section>

--- a/src/app/txid/[txId]/TxDetails/__tests__/__snapshots__/Broadcast.test.tsx.snap
+++ b/src/app/txid/[txId]/TxDetails/__tests__/__snapshots__/Broadcast.test.tsx.snap
@@ -35,7 +35,7 @@ exports[`<Broadcast /> renders correctly 1`] = `
           <span
             class="chakra-text css-nvxyq8"
           >
-            a year ago
+            2 years ago
           </span>
         </div>
       </div>

--- a/src/common/hooks/useInfiniteQueryResult.ts
+++ b/src/common/hooks/useInfiniteQueryResult.ts
@@ -31,9 +31,11 @@ export function useSuspenseInfiniteQueryResult<T>(
   limit?: number
 ) {
   return useMemo(() => {
-    return response.data?.pages
-      .map(page => page.results)
-      .flat()
-      .slice(0, limit) || []
+    return (
+      response.data?.pages
+        .map(page => page.results)
+        .flat()
+        .slice(0, limit) || []
+    );
   }, [limit, response.data?.pages]);
 }


### PR DESCRIPTION
Issue: https://github.com/hirosystems/explorer/issues/1376

I added this canonical key value pair when the block is not canonical to show when the block is orphaned or not. 
@GinaAbrams Do you think this is ok? Or do you want to design this differently?

![image](https://github.com/hirosystems/explorer/assets/20312835/52ea01ef-4a4c-4689-a35f-c56e09709f15)
