### PR TITLE
fix: fixed filters resetting when clicking load more

### DIFF
--- a/src/features/txs-list/ConfirmedTxsList.tsx
+++ b/src/features/txs-list/ConfirmedTxsList.tsx
@@ -1,5 +1,3 @@
-import * as React from 'react';
-
 import { Transaction } from '@stacks/stacks-blockchain-api-types';
 
 import { ExplorerErrorBoundary } from '../../app/_components/ErrorBoundary';
@@ -34,8 +32,6 @@ function ConfirmedTxsListBase({
   const response = useConfirmedTransactionsInfinite(filters);
   const txs = useInfiniteQueryResult<Transaction>(response, limit);
 
-  if (response.isLoading || response.isFetching) return <SkeletonTxsList />;
-
   return (
     <Box pb={6}>
       {!!filters && (
@@ -56,7 +52,13 @@ function ConfirmedTxsListBase({
           {showFilterButton && <FilterButton />}
         </Flex>
       )}
-      {!txs?.length ? <NoTxs /> : <FilteredTxs txs={txs} TxListItem={TxListItem} />}
+      {response.isLoading || response.isFetching ? (
+        <SkeletonTxsList />
+      ) : !txs?.length ? (
+        <NoTxs />
+      ) : (
+        <FilteredTxs txs={txs} TxListItem={TxListItem} />
+      )}
       <ListFooter
         isLoading={response.isFetchingNextPage}
         hasNextPage={response.hasNextPage}

--- a/src/features/txs-list/tabs/TxListTabs.tsx
+++ b/src/features/txs-list/tabs/TxListTabs.tsx
@@ -1,6 +1,5 @@
 'use client';
 
-import { FilterProps } from '../../../app/search/filters';
 import { FlexProps } from '../../../ui/Flex';
 import { ConfirmedTxsList } from '../ConfirmedTxsList';
 import { MempoolTxsList } from '../MempoolTxsList';


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [ ] Refactor
- [ ] Feature
- [X] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
<!--- Describe your changes in detail -->
The filter state was getting reset because when the load more was clicked and the request was in flight we returned different jsx, loading jsx, which wiped the filter jsx from the dom, resetting the filters state.

## Issue ticket number and link
https://github.com/hirosystems/explorer/issues/1828

# Checklist:
- [X] I have performed a self-review of my code.
- [X] I have tested the change on desktop and mobile.
- [X] I have added thorough tests where applicable.
- [X] I've added analytics and error logging where applicable.

## Screenshots (if appropriate):
<!--- Add screenshots of your changes -->
