### PR TITLE
fix: block time

### DIFF
--- a/src/app/_components/BlockList/BlockListItem.tsx
+++ b/src/app/_components/BlockList/BlockListItem.tsx
@@ -45,7 +45,7 @@ export const BlockListItem: React.FC<{ block: Block } & FlexProps> = React.memo(
           ),
         }}
         rightContent={{
-          title: toRelativeTime(block.burn_block_time * 1000),
+          title: toRelativeTime(block.block_time * 1000),
           subtitle: truncateMiddle(block.hash),
         }}
         {...rest}

--- a/src/app/_components/BlockList/LayoutA/useBlockList.ts
+++ b/src/app/_components/BlockList/LayoutA/useBlockList.ts
@@ -21,7 +21,7 @@ const createBlockUIBlock = (block: NakamotoBlock): UIBlock => ({
   type: UIBlockType.Block,
   height: block.height,
   hash: block.hash,
-  timestamp: block.burn_block_time,
+  timestamp: block.block_time,
   txsCount: block.tx_count,
 });
 

--- a/src/app/_components/BlockList/UpdatedBlockList.tsx
+++ b/src/app/_components/BlockList/UpdatedBlockList.tsx
@@ -37,7 +37,7 @@ export const BlockListItem: React.FC<{ block: Block } & FlexProps> = React.memo(
           key={block.hash}
           hash={block.hash}
           height={block.height}
-          timestamp={block.burn_block_time}
+          timestamp={block.block_time}
           txsCount={block.txs.length}
           icon={<Icon as={StxIcon} size={2.5} color={'white'} />}
         />

--- a/src/app/block/[hash]/PageClient.tsx
+++ b/src/app/block/[hash]/PageClient.tsx
@@ -57,10 +57,7 @@ export default function BlockPage({ params: { hash } }: any) {
                   />
                 }
               />
-              <KeyValueHorizontal
-                label={'Mined'}
-                value={<Timestamp ts={block.burn_block_time} />}
-              />
+              <KeyValueHorizontal label={'Mined'} value={<Timestamp ts={block.block_time} />} />
               <KeyValueHorizontal
                 label={'Transactions'}
                 value={<Value>{block.txs.length}</Value>}

--- a/src/common/components/transaction-item.tsx
+++ b/src/common/components/transaction-item.tsx
@@ -30,6 +30,9 @@ export interface TxItemProps extends FlexProps {
 }
 
 const getTransactionTime = (tx: Transaction | MempoolTransaction) => {
+  if ((tx as any).block_time !== 'undefined' && (tx as any).block_time !== -1) {
+    return (tx as any).block_time;
+  }
   if (typeof (tx as any).burn_block_time !== 'undefined' && (tx as any).burn_block_time !== -1) {
     return (tx as any).burn_block_time;
   } else if ((tx as any).burn_block_time === -1) {


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [ ] Refactor
- [ ] Feature
- [X] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
Context - https://hiropbc.slack.com/archives/C03TU42NL05/p1728686112307179
The Stacks block timestamp is inconsistent on the transaction page vs the blocks list page on Primary testnet.
block page uses burn_block_time while block list uses block_time
Both should use block_time

## Issue ticket number and link

# Checklist:
- [X] I have performed a self-review of my code.
- [X] I have tested the change on desktop and mobile.
- [X] I have added thorough tests where applicable.
- [X] I've added analytics and error logging where applicable.

## Screenshots (if appropriate):
<!--- Add screenshots of your changes -->
