### PR TITLE
fix: allow custom network ids

### DIFF
--- a/src/common/components/modals/AddNetwork/AddNetworkForm.tsx
+++ b/src/common/components/modals/AddNetwork/AddNetworkForm.tsx
@@ -23,7 +23,7 @@ import { Text } from '../../../../ui/Text';
 import { NetworkIdModeMap } from '../../../constants/network';
 import { useGlobalContext } from '../../../context/useGlobalContext';
 import { useAppDispatch } from '../../../state/hooks';
-import { Network } from '../../../types/network';
+import { Network, NetworkModes } from '../../../types/network';
 import { getQueryParams } from '../../../utils/buildUrl';
 import { closeModal } from '../modal-slice';
 import { buildCustomNetworkUrl, fetchCustomNetworkId, validateUrl } from './utils';
@@ -70,10 +70,7 @@ export const AddNetworkForm: FC = () => {
           errors.url = networkUrlErrorMessage;
         } else {
           try {
-            const networkId = await fetchCustomNetworkId(
-              buildCustomNetworkUrl(values.url),
-              values.isSubnet
-            );
+            const networkId = await fetchCustomNetworkId(buildCustomNetworkUrl(values.url));
             if (!networkId) {
               errors.genericError = 'The API did not return a valid network_id.';
             }
@@ -130,7 +127,7 @@ export const AddNetworkForm: FC = () => {
         isSubnet,
       }) => {
         const networkUrl = buildCustomNetworkUrl(url);
-        const networkId = await fetchCustomNetworkId(networkUrl, isSubnet);
+        const networkId = await fetchCustomNetworkId(networkUrl);
 
         if (networkId) {
           const network: Network = {
@@ -140,7 +137,7 @@ export const AddNetworkForm: FC = () => {
             btcTxBaseUrl,
             btcAddressBaseUrl,
             networkId,
-            mode: NetworkIdModeMap[networkId],
+            mode: NetworkIdModeMap[networkId] ?? NetworkModes.Testnet,
             isCustomNetwork: true,
             isSubnet,
           };

--- a/src/common/components/modals/AddNetwork/utils.ts
+++ b/src/common/components/modals/AddNetwork/utils.ts
@@ -37,18 +37,9 @@ export const buildCustomNetworkUrl = (url: string) => {
   }${pathname || ''}`;
 };
 
-export const fetchCustomNetworkId: (
-  url: string,
-  isSubnet: boolean
-) => Promise<ChainID | undefined> = (url, isSubnet) => {
+export const fetchCustomNetworkId: (url: string) => Promise<ChainID | undefined> = url => {
   return fetchFromApi(url)(DEFAULT_V2_INFO_ENDPOINT)
     .then(res => res.json())
-    .then(res =>
-      !isSubnet
-        ? Object.values(ChainID).includes(res.network_id)
-          ? (res.network_id as ChainID)
-          : undefined
-        : res.network_id
-    )
+    .then(res => res.network_id)
     .catch();
 };

--- a/src/common/constants/network.ts
+++ b/src/common/constants/network.ts
@@ -64,7 +64,7 @@ export const nakamotoTestnetNetwork: Network = {
   btcBlockBaseUrl: NetworkModeBtcBlockBaseUrlMap[NetworkModes.Testnet],
   btcTxBaseUrl: NetworkModeBtcTxBaseUrlMap[NetworkModes.Testnet],
   btcAddressBaseUrl: NetworkModeBtcAddressBaseUrlMap[NetworkModes.Testnet],
-  networkId: ChainID.Testnet,
+  networkId: 2147483904 as ChainID,
   mode: NetworkModes.Testnet,
   isCustomNetwork: true,
 };

--- a/src/common/context/GlobalContextProvider.tsx
+++ b/src/common/context/GlobalContextProvider.tsx
@@ -225,7 +225,7 @@ export const GlobalContextProvider: FC<{
   useEffect(() => {
     const addCustomNetworkFromQuery = async () => {
       const networkUrl = buildCustomNetworkUrl(queryApiUrl);
-      const networkId = await fetchCustomNetworkId(networkUrl, false);
+      const networkId = await fetchCustomNetworkId(networkUrl);
       if (networkId) {
         const network: Network = {
           label: queryApiUrl,
@@ -236,7 +236,7 @@ export const GlobalContextProvider: FC<{
           btcAddressBaseUrl:
             queryBtcAddressBaseUrl || NetworkModeBtcAddressBaseUrlMap[NetworkModes.Mainnet],
           networkId,
-          mode: NetworkIdModeMap[networkId],
+          mode: NetworkIdModeMap[networkId] ?? NetworkModes.Testnet,
           isCustomNetwork: true,
           isSubnet: false,
         };

--- a/src/common/context/__tests__/GlobalContext.test.tsx
+++ b/src/common/context/__tests__/GlobalContext.test.tsx
@@ -102,7 +102,7 @@ describe('GlobalContext', () => {
     expect(Object.keys(networks).length).toBe(5);
 
     await waitFor(() => {
-      expect(fetchCustomNetworkId).toHaveBeenCalledWith(customApiUrl, false);
+      expect(fetchCustomNetworkId).toHaveBeenCalledWith(customApiUrl);
     });
 
     await waitFor(() => {

--- a/src/common/hooks/useStacksNetwork.ts
+++ b/src/common/hooks/useStacksNetwork.ts
@@ -8,7 +8,8 @@ export const useStacksNetwork = (): StacksTestnet | StacksMainnet => {
   const selectedNetwork = useGlobalContext().activeNetwork;
   const apiServer = selectedNetwork.url;
   const networkMode = selectedNetwork.mode;
-  const Network = networkMode === NetworkModes.Testnet ? StacksTestnet : StacksMainnet;
+  const Network = networkMode === NetworkModes.Mainnet ? StacksMainnet : StacksTestnet; // default to testnet if network id / mode is not known
   const network = new Network({ url: apiServer, fetchFn: fetchWithApiKey });
+  network.chainId = selectedNetwork.networkId;
   return network;
 };


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [ ] Refactor
- [x] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
Allows for custom network Ids to be detected in the existing subnet logic (flag is not needed anymore, as we want the network_id to always be detected)

I default the `mode` to Testnet, since I'm assuming custom/not-known network ids will more likely be Testnet-based. This isn't perfect, but good enough imo, as there are no networks that customize other params (especially not Mainnet-based).

# Checklist:
- [x] I have performed a self-review of my code.
- [ ] I have tested the change on desktop and mobile.
- [ ] I have added thorough tests where applicable.
- [ ] I've added analytics and error logging where applicable.
