### PR TITLE
fix: removed pending blocks ui from everything but mainnet

### DIFF
--- a/src/app/txid/[txId]/TxPage.tsx
+++ b/src/app/txid/[txId]/TxPage.tsx
@@ -58,10 +58,13 @@ export const TxPage: React.FC<{
   children?: ReactNode;
 }> = ({ tx, contractId, txDetails, children }) => {
   const txStatus = getTransactionStatus(tx);
-  const { activeNetwork } = useGlobalContext();
+  const { activeNetwork, activeNetworkKey } = useGlobalContext();
+  const isMainnet = activeNetworkKey === 'https://api.hiro.so';
 
   const showBlocksVisualizer =
-    !activeNetwork.isSubnet && (txStatus === 'success_microblock' || txStatus === 'pending');
+    isMainnet &&
+    !activeNetwork.isSubnet &&
+    (txStatus === 'success_microblock' || txStatus === 'pending');
 
   return (
     <>


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [ ] Refactor
- [ ] Feature
- [X] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
Context https://github.com/hirosystems/explorer/issues/1854
The pending blocks ui doesnt make sense for any network that is naka 3.0 ready, so we are going to remove it

## Issue ticket number and link
https://github.com/hirosystems/explorer/issues/1854

# Checklist:
- [X] I have performed a self-review of my code.
- [X] I have tested the change on desktop and mobile.
- [X] I have added thorough tests where applicable.
- [X] I've added analytics and error logging where applicable.

## Screenshots (if appropriate):
<!--- Add screenshots of your changes -->
