### PR TITLE
fix: fixed supply #s

### DIFF
--- a/src/app/_components/Stats/StxSupply/index.tsx
+++ b/src/app/_components/Stats/StxSupply/index.tsx
@@ -1,8 +1,6 @@
 'use client';
 
-import { useColorMode } from '@chakra-ui/react';
-import { Infinity, Info } from '@phosphor-icons/react';
-import * as React from 'react';
+import { Info } from '@phosphor-icons/react';
 
 import { useGlobalContext } from '../../../../common/context/useGlobalContext';
 import { useSuspenseStxSupply } from '../../../../common/queries/useStxSupply';
@@ -12,20 +10,18 @@ import { Flex } from '../../../../ui/Flex';
 import { GridProps } from '../../../../ui/Grid';
 import { Icon } from '../../../../ui/Icon';
 import { Tooltip } from '../../../../ui/Tooltip';
-import { useStxSupply } from '../../../signers/data/useStxSupply';
 import { ExplorerErrorBoundary } from '../../ErrorBoundary';
 import { StatSection } from '../StatSection';
 
 function StxSupplyBase(props: GridProps) {
   const {
-    data: { total_stx, unlocked_stx },
+    data: { total_stx, unlocked_stx, total_stx_year_2050 },
   } = useSuspenseStxSupply();
-  const { circulatingSupply } = useStxSupply();
-  const circulatingSupplyNumber = circulatingSupply ? Number(circulatingSupply) : 0;
+  const circulatingSupplyNumber = unlocked_stx ? Number(unlocked_stx) : 0;
   const circulatingSupplyFormatted = numberToString(circulatingSupplyNumber);
-  const totalSupplyNumber = unlocked_stx ? Number(unlocked_stx) : 0;
+  const totalSupplyNumber = total_stx ? Number(total_stx) : 0;
   const totalSupplyFormatted = numberToString(totalSupplyNumber);
-  const maxSupplyBy2050Number = total_stx ? Number(total_stx) : 0;
+  const maxSupplyBy2050Number = total_stx_year_2050 ? Number(total_stx_year_2050) : 0;
   const maxSupplyBy2050Formatted = numberToString(maxSupplyBy2050Number);
   const percentageUnlocked = ((circulatingSupplyNumber / totalSupplyNumber) * 100).toFixed(1);
   const isMainnet = useGlobalContext().activeNetwork.mode === 'mainnet';

--- a/src/common/queries/useStxSupply.ts
+++ b/src/common/queries/useStxSupply.ts
@@ -1,12 +1,20 @@
 import { useSuspenseQuery } from '@tanstack/react-query';
 
-import { useApi } from '../api/useApi';
+import { useGlobalContext } from '../context/useGlobalContext';
+
+interface StxSupplyResponse {
+  unlocked_percent: string;
+  total_stx: string;
+  total_stx_year_2050: string;
+  unlocked_stx: string;
+  block_height: number;
+}
 
 export const useSuspenseStxSupply = () => {
-  const api = useApi();
-  return useSuspenseQuery({
+  const { url: activeNetworkUrl } = useGlobalContext().activeNetwork;
+  return useSuspenseQuery<StxSupplyResponse>({
     queryKey: ['stx-supply'],
-    queryFn: () => api.infoApi.getStxSupply({}),
+    queryFn: () => fetch(`${activeNetworkUrl}/extended/v1/stx_supply`).then(res => res.json()),
     staleTime: 30 * 60 * 1000,
   });
 };


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [ ] Refactor
- [ ] Feature
- [X] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
Fixes supply stats on the homepage.
Slack context: https://hiropbc.slack.com/archives/C03TU42NL05/p1730334206249929?thread_ts=1730330803.165729&cid=C03TU42NL05

the explorer is dividing circulatingSupply = total_liquid_supply_ustx / MICROSTACKS_IN_STACKS = 1501825000.29185
by
totalSupplyNumber = unlocked_stx = 1498769444.73627
total_liquid_supply_ustx is taken from /v2/pox
unlocked_stx is taken from api.infoApi.getStxSupply({})
Interestingly, total_stx, taken from api.infoApi.getStxSupply({}), is 1498769444.73627, which is the same as unlocked_stx, as well as less than total_liquid_supply_ustx.
I can see that the response for api.infoApi.getStxSupply({}) has changed. It now includes total_stx_year_2050, which we weren't using before. I will fix that.
The main issue is that we are taking the circulating supply from total_liquid_supply_ustx from /v2/pox, which is returning a number that is higher than the total_stx and  unlocked_stx returned from https://api.hiro.so/extended/v1/stx_supply.
It seems like we should use unlocked_stx as the circulating supply and total_stx as total stx. Both are the same so the % unlocked should be 100%.
The API should investigate why total_liquid_supply_ustx taken from /v2/pox is returning a higher # 
[@matt](https://hiropbc.slack.com/team/UELD4763G)
 
[@rafael](https://hiropbc.slack.com/team/U02A4BLB3FF)

## Issue ticket number and link

# Checklist:
- [X] I have performed a self-review of my code.
- [X] I have tested the change on desktop and mobile.
- [X] I have added thorough tests where applicable.
- [X] I've added analytics and error logging where applicable.

## Screenshots (if appropriate):
<!--- Add screenshots of your changes -->
