### PR TITLE
fix: fixed sbtc circulating supply

### DIFF
--- a/src/app/token/[tokenId]/getTokenInfo.ts
+++ b/src/app/token/[tokenId]/getTokenInfo.ts
@@ -1,6 +1,7 @@
 import { ContractResponse } from '@/common/types/tx';
 import { FtMetadataResponse } from '@hirosystems/token-metadata-api-client';
 
+import { getIsSBTC } from '../../../app/tokens/utils';
 import { LUNAR_CRUSH_API_KEY } from '../../../common/constants/env';
 import { LunarCrushCoin } from '../../../common/types/lunarCrush';
 import { getCacheClient } from '../../../common/utils/cache-client';
@@ -121,15 +122,17 @@ async function getDetailedTokenInfoFromLunarCrush(tokenId: string, basicTokenInf
       };
     }
 
+    const isSBTC = getIsSBTC(tokenId);
+
     const name = tokenInfoResponse?.data?.name || basicTokenInfo.name || null;
     const symbol = tokenInfoResponse?.data?.symbol || basicTokenInfo.symbol || null;
     const categories: string[] = [];
 
     const totalSupply = basicTokenInfo.totalSupply || null;
     const circulatingSupplyFromBasicTokenInfo = basicTokenInfo.circulatingSupply || null;
-    const circulatingSupply =
-      tokenInfoResponse?.data?.circulating_supply || circulatingSupplyFromBasicTokenInfo || null;
-    // const circulatingSupply = tokenInfoResponse?.data?.circulating_supply || null;
+    const circulatingSupply = isSBTC
+      ? circulatingSupplyFromBasicTokenInfo // LunarCrush is returning an incorrect circulating supply for SBTC. Use the circulating supply from the holders endpoint on Stacks API instead.
+      : tokenInfoResponse?.data?.circulating_supply || circulatingSupplyFromBasicTokenInfo || null;
     const imageUri = basicTokenInfo.imageUri || undefined;
 
     const currentPrice = tokenInfoResponse?.data?.price || null;


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [ ] Refactor
- [ ] Feature
- [X] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
Lunar Crush API is returning an inaccurate circulating supply for sBTC. Reverting the logic to use Stacks API holders endpoint for circulating supply just for sBTC.

## Issue ticket number and link

# Checklist:
- [X] I have performed a self-review of my code.
- [X] I have tested the change on desktop and mobile.
- [X] I have added thorough tests where applicable.
- [X] I've added analytics and error logging where applicable.

## Screenshots (if appropriate):
<!--- Add screenshots of your changes -->
