### PR TITLE
fix: overriding marketcap

### DIFF
--- a/src/app/token/[tokenId]/TokenInfo/MarketCap.tsx
+++ b/src/app/token/[tokenId]/TokenInfo/MarketCap.tsx
@@ -11,16 +11,29 @@ export const MarketCap: FC<
     marketCap: number | null | undefined;
     tradingVolume24h: number | null | undefined;
     tradingVolumeChangePercentage24h: number | null | undefined;
+    marketCapOverride?: number | null | undefined;
   }
-> = ({ marketCap, tradingVolumeChangePercentage24h, tradingVolume24h, ...gridProps }) => {
+> = ({
+  marketCap,
+  tradingVolumeChangePercentage24h,
+  tradingVolume24h,
+  marketCapOverride,
+  ...gridProps
+}) => {
   return (
     <StatSection
       title="Market Cap"
-      bodyMainText={marketCap ? `$${abbreviateNumber(marketCap)}` : 'N/A'}
+      bodyMainText={
+        marketCapOverride
+          ? `$${abbreviateNumber(marketCapOverride, 2)}`
+          : marketCap
+            ? `$${abbreviateNumber(marketCap, 2)}`
+            : 'N/A'
+      }
       bodySecondaryText={null}
       caption={
         <Flex fontSize={'12px'} fontWeight="500" alignItems={'center'} gap={'6px'}>
-          Trading Volume: ${tradingVolume24h ? abbreviateNumber(tradingVolume24h) : 'N/A'}
+          Trading Volume: ${tradingVolume24h ? abbreviateNumber(tradingVolume24h, 2) : 'N/A'}
           {tradingVolumeChangePercentage24h ? (
             <TrendArrow change={tradingVolumeChangePercentage24h} size={'11px'} />
           ) : null}

--- a/src/app/token/[tokenId]/TokenInfo/index.tsx
+++ b/src/app/token/[tokenId]/TokenInfo/index.tsx
@@ -1,6 +1,7 @@
 import { FC } from 'react';
 import { ErrorBoundary } from 'react-error-boundary';
 
+import { getIsSBTC } from '../../../../app/tokens/utils';
 import { Wrapper } from '../../../_components/Stats/Wrapper';
 import { TokenInfoProps } from '../types';
 import { MarketCap } from './MarketCap';
@@ -12,14 +13,18 @@ export const TokenInfo: FC<{ tokenInfo: TokenInfoProps; tokenId: string }> = ({
   tokenInfo,
   tokenId,
 }) => {
+  const circulatingSupply =
+    tokenInfo?.extended?.circulatingSupply || tokenInfo?.basic?.circulatingSupply;
+  const currentPrice = tokenInfo?.extended?.currentPrice;
+  const isSBTC = getIsSBTC(tokenId);
+  const sBTCMarketCapOverride = // LunarCrush is returning an incorrect circulating supply for SBTC, resulting in an incorrect market cap. Manually overriding it here.
+    circulatingSupply && currentPrice ? circulatingSupply * currentPrice : undefined;
   return (
     <ErrorBoundary fallbackRender={() => null}>
       <Wrapper>
         <Supply
           borderRightWidth={['0px', '0px', '1px', '1px']}
-          circulatingSupply={
-            tokenInfo.basic?.circulatingSupply || tokenInfo.extended?.circulatingSupply
-          }
+          circulatingSupply={circulatingSupply}
           totalSupply={tokenInfo.basic?.totalSupply}
         />
         <Price
@@ -34,6 +39,7 @@ export const TokenInfo: FC<{ tokenInfo: TokenInfoProps; tokenId: string }> = ({
           tradingVolume24h={tokenInfo.extended?.tradingVolume24h}
           tradingVolumeChangePercentage24h={tokenInfo.extended?.tradingVolumeChangePercentage24h}
           borderRightWidth={['0px', '0px', '1px', '1px']}
+          marketCapOverride={isSBTC ? sBTCMarketCapOverride : undefined}
         />
         <Transaction txId={tokenId} marketCapRank={tokenInfo.extended?.marketCapRank} />
       </Wrapper>


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [ ] Refactor
- [ ] Feature
- [X] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
LunarCrush is returning an incorrect circulating supply for SBTC, resulting in an incorrect market cap. Manually overriding it here.

## Issue ticket number and link

# Checklist:
- [X] I have performed a self-review of my code.
- [X] I have tested the change on desktop and mobile.
- [X] I have added thorough tests where applicable.
- [X] I've added analytics and error logging where applicable.

## Screenshots (if appropriate):
<!--- Add screenshots of your changes -->
