### PR TITLE
fix: search: return null when entity url exists

### DIFF
--- a/src/features/search/dropdown/search-results-card.tsx
+++ b/src/features/search/dropdown/search-results-card.tsx
@@ -140,19 +140,23 @@ export function SearchResultsCard({
   const searchPageUrl = useSearchPageUrl(searchTerm, network);
   const router = useRouter();
   const activeNetwork = useGlobalContext().activeNetwork;
+  const entityUrl = getSearchEntityUrl(activeNetwork, data);
 
   useEffect(() => {
-    const entityUrl = getSearchEntityUrl(activeNetwork, data);
     if (entityUrl) {
       router.push(entityUrl);
     }
-  }, [activeNetwork, data, router]);
+  }, [activeNetwork, data, entityUrl, router]);
 
   const isSearchPage = usePathname() === '/search';
 
   if (!isFocused || isSearchPage) return null;
 
   const totalCount = data && 'metadata' in data.result ? data?.result?.metadata?.totalCount : 0;
+
+  if (entityUrl) {
+    return null;
+  }
 
   return (
     <Section


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
Return null when entity url exists to prevent rendering results card after redirect

## Issue ticket number and link

# Checklist:
- [x] I have performed a self-review of my code.
- [ ] I have tested the change on desktop and mobile.
- [ ] I have added thorough tests where applicable.
- [ ] I've added analytics and error logging where applicable.

## Screenshots (if appropriate):
<!--- Add screenshots of your changes -->
