### PR TITLE
fix: fixed small button recipe

### DIFF
--- a/src/ui/theme/recipes/ButtonRecipe.ts
+++ b/src/ui/theme/recipes/ButtonRecipe.ts
@@ -160,6 +160,8 @@ export const buttonRecipe = defineRecipe({
       small: {
         fontSize: 'xs',
         fontWeight: 'medium',
+        py: 2,
+        px: 3,
       },
       big: {
         fontSize: 'sm',


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [ ] Refactor
- [ ] Feature
- [X] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
There was a regression with the "Add a Network" button in the settings dropdown. This fixes it. Somehow, the padding styles were removed from the button recipe

## Issue ticket number and link

# Checklist:
- [X] I have performed a self-review of my code.
- [X] I have tested the change on desktop and mobile.
- [ ] I have added thorough tests where applicable.
- [ ] I've added analytics and error logging where applicable.

## Screenshots (if appropriate):
<!--- Add screenshots of your changes -->
