### PR TITLE
feat: sign bot commits

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -69,6 +69,9 @@ jobs:
           docker_tag: ${{ github.ref_type == "branch" ? ${{ steps.docker_push.outputs.digest }} || ${{ github.ref_name }} ))
           application_path: manifests/sites/explorer/${{ env.DEPLOY_ENV }}/base/kustomization.yaml
           gh_token: ${{ secrets.DEVOPS_K8S_REPO_PAT }}
+          gpg_key: ${{ secrets.HIRO_DEVOPS_GPG_KEY }}
+          gpg_key_passphrase: ${{ secrets.HIRO_DEVOPS_GPG_KEY_PASSPHRASE }}
+          gpg_key_id: ${{ secrets.HIRO_DEVOPS_GPG_KEY_ID }}
 
   auto-approve-dev:
     runs-on: ubuntu-latest
@@ -108,6 +111,9 @@ jobs:
           docker_tag: ${{ github.ref_type == "branch" ? ${{ steps.docker_push.outputs.digest }} || ${{ github.ref_name }} ))
           application_path: manifests/sites/explorer/${{ env.DEPLOY_ENV }}/base/kustomization.yaml
           gh_token: ${{ secrets.DEVOPS_K8S_REPO_PAT }}
+          gpg_key: ${{ secrets.HIRO_DEVOPS_GPG_KEY }}
+          gpg_key_passphrase: ${{ secrets.HIRO_DEVOPS_GPG_KEY_PASSPHRASE }}
+          gpg_key_id: ${{ secrets.HIRO_DEVOPS_GPG_KEY_ID }}
 
   auto-approve-staging:
     runs-on: ubuntu-latest
@@ -147,3 +153,6 @@ jobs:
           docker_tag: ${{ github.ref_type == "branch" ? ${{ steps.docker_push.outputs.digest }} || ${{ github.ref_name }} ))
           application_path: manifests/sites/explorer/${{ env.DEPLOY_ENV }}/base/kustomization.yaml
           gh_token: ${{ secrets.DEVOPS_K8S_REPO_PAT }}
+          gpg_key: ${{ secrets.HIRO_DEVOPS_GPG_KEY }}
+          gpg_key_passphrase: ${{ secrets.HIRO_DEVOPS_GPG_KEY_PASSPHRASE }}
+          gpg_key_id: ${{ secrets.HIRO_DEVOPS_GPG_KEY_ID }}


### PR DESCRIPTION
This change passes the appropriate secrets downstream to the composite Github action workflow needed for automated GPG signing of all CI/CD commits.