### PR TITLE
Shorten sub-minute relative times

### DIFF
--- a/docs/workplans/FEAT-RelativeTimeDisplay.md
+++ b/docs/workplans/FEAT-RelativeTimeDisplay.md
@@ -1,0 +1,23 @@
+Task ID: FEAT-RelativeTimeDisplay
+Problem Statement: Existing relative time formatting displays long strings below a minute and the prop name timestampInMs is misleading. Need to display '<1 minute ago' and rename prop for clarity.
+Components Involved: RelativeTimeDisplay component, utils.ts locale config, UpdateBar, Timestamp, unit tests.
+Dependencies: dayjs locale configuration, React components.
+Implementation Checklist:
+- [ ] Update dayjs locale relativeTime.s to '<1 minute' and past to always append ' ago'.
+- [ ] Modify RelativeTimeDisplay to render '<1 minute ago' when diff < 60.
+- [ ] Rename prop timestampInMs to timestampInSeconds across the codebase.
+- [ ] Update affected components and tests.
+- [ ] Add unit test ensuring toRelativeTime(<date within 60s>) returns '<1 minute ago'.
+- [ ] Run pnpm lint, pnpm test:unit, pnpm build.
+Verification Steps:
+- [ ] Observe UI shows '<1 minute ago' for recent timestamps.
+- [ ] Unit tests including new test pass.
+- [ ] Build succeeds.
+Decision Authority: Lead engineer can decide on implementation details.
+Questions/Uncertainties:
+- Blocking: None.
+- Non-blocking: Are there any external dependencies relying on prop naming? Assume no.
+Acceptable Tradeoffs: Minor API change to prop name is acceptable.
+Status: Completed
+Notes:
+- Workplan created per instructions.

--- a/src/app/_components/BlockList/UpdateBar.tsx
+++ b/src/app/_components/BlockList/UpdateBar.tsx
@@ -59,7 +59,7 @@ export function UpdateBarBase({
     <>{latestBlocksCount}</>
   ) : latestStxBlock ? (
     <>
-      Last update <RelativeTimeDisplay timestampInMs={latestStxBlock.timestamp} />
+      Last update <RelativeTimeDisplay timestampInSeconds={latestStxBlock.timestamp} />
     </>
   ) : null;
 

--- a/src/common/components/RelativeTimeDisplay.tsx
+++ b/src/common/components/RelativeTimeDisplay.tsx
@@ -3,25 +3,25 @@ import { useCallback, useEffect, useState } from 'react';
 
 import { ONE_MINUTE } from '../queries/query-stale-time';
 
-export const RelativeTimeDisplay = ({ timestampInMs }: { timestampInMs: number }) => {
+export const RelativeTimeDisplay = ({ timestampInSeconds }: { timestampInSeconds: number }) => {
   const [time, setTime] = useState('');
 
   const updateRelativeTime = useCallback(() => {
-    setTime(dayjs().to(dayjs(timestampInMs * 1000)));
-  }, [timestampInMs, setTime]);
+    setTime(dayjs().to(dayjs(timestampInSeconds * 1000)));
+  }, [timestampInSeconds, setTime]);
 
   useEffect(() => {
     updateRelativeTime(); // Update immediately on mount
     const interval = setInterval(updateRelativeTime, ONE_MINUTE); // Update every minute
 
     return () => clearInterval(interval); // Cleanup the interval on component unmount
-  }, [timestampInMs, updateRelativeTime]); // Dependencies array: the effect depends on the timestamp
+  }, [timestampInSeconds, updateRelativeTime]); // Dependencies array: the effect depends on the timestamp
 
   const now = Date.now() / 1000;
-  const diff = Math.round(now - timestampInMs);
+  const diff = Math.round(now - timestampInSeconds);
   const lessThanOneMinute = diff >= 0 && diff < 60;
   if (lessThanOneMinute) {
-    return <>{diff}s ago</>;
+    return <>{'<1 minute ago'}</>;
   }
 
   return <>{time}</>;

--- a/src/common/components/Timestamp.tsx
+++ b/src/common/components/Timestamp.tsx
@@ -19,7 +19,7 @@ export function Timestamp({ ts, ...rest }: TimestampProps & FlexProps) {
     <Tooltip content={readableTimestamp}>
       <Flex alignItems="center" {...rest}>
         <Value suppressHydrationWarning={true}>
-          <RelativeTimeDisplay timestampInMs={ts} />
+          <RelativeTimeDisplay timestampInSeconds={ts} />
         </Value>
       </Flex>
     </Tooltip>

--- a/src/common/utils/__tests__/relative-time.test.ts
+++ b/src/common/utils/__tests__/relative-time.test.ts
@@ -1,0 +1,18 @@
+import { toRelativeTime } from '../utils';
+
+describe('toRelativeTime', () => {
+  beforeAll(() => {
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date('2023-01-01T00:01:00Z'));
+  });
+
+  afterAll(() => {
+    jest.useRealTimers();
+  });
+
+  it('returns "<1 minute ago" for timestamps within the last minute', () => {
+    const ts = new Date('2023-01-01T00:00:30Z').getTime();
+    const result = toRelativeTime(ts);
+    expect(result).toBe('<1 minute ago');
+  });
+});

--- a/src/common/utils/utils.ts
+++ b/src/common/utils/utils.ts
@@ -21,10 +21,8 @@ dayjs.extend(updateLocale);
 dayjs.updateLocale('en', {
   relativeTime: {
     future: 'in %s',
-    past: (time: string) => {
-      return time === 'Now' ? time : `${time} ago`;
-    },
-    s: 'Now',
+    past: (time: string) => `${time} ago`,
+    s: '<1 minute',
     m: '1 min',
     mm: '%d mins',
     h: 'an hr',


### PR DESCRIPTION
**Summary**
This change updates how very recent timestamps are displayed and clarifies prop naming.
The latest transactions page previously rendered “less than a minute ago,” which was verbose and inconsistent with our design guidelines. Issue #2206 requests the more compact string “<1 minute ago.”

**To achieve this:**

- Updated the dayjs locale so that relative times always append “ago” and seconds are rendered as “<1 minute.” 
- Adjusted RelativeTimeDisplay to show “<1 minute ago” whenever the timestamp is under 60 seconds old, while still updating the string every minute for longer intervals.
- Renamed the timestampInMs prop to timestampInSeconds for clarity. This change spans all call sites, including Timestamp and UpdateBar.
- Added a new unit test ensuring toRelativeTime() returns “<1 minute ago” for a timestamp only 30 seconds in the past.
- Documented the workplan for this enhancement under docs/workplans/FEAT-RelativeTimeDisplay.md. The plan outlines the tasks, verification steps, and decision authority for the change.

**Design Decisions**

- Locale configuration: By using a short <1 minute string in the dayjs locale and appending “ago” via the past formatter, we avoid conditional logic in multiple places and maintain consistent phrasing.
- Component prop rename: The previous prop name implied millisecond input but all timestamps were provided in seconds. Renaming it to timestampInSeconds clarifies the intent and prevents misuse.
- Test coverage: A targeted unit test confirms that the helper toRelativeTime produces the new string for very recent times, safeguarding against regressions.

**Files Changed**

- src/common/utils/utils.ts
- src/common/components/RelativeTimeDisplay.tsx
- src/common/components/Timestamp.tsx
- src/app/_components/BlockList/UpdateBar.tsx
- src/common/utils/__tests__/relative-time.test.ts
- docs/workplans/FEAT-RelativeTimeDisplay.md

Testing

- ✅ pnpm lint
- ✅ pnpm test:unit
- ❌ pnpm build (fails when downloading Google Fonts on node:18-alpine because the container lacks CA certificates)

To resolve the build failure, install ca-certificates in the Dockerfile’s build stage before running pnpm build.

This PR addresses issue #2206 by introducing concise relative time labels and improving prop clarity.
