### PR TITLE
feat: shorten '<1 minute ago' display

### DIFF
--- a/src/common/utils/__tests__/time-utils.test.ts
+++ b/src/common/utils/__tests__/time-utils.test.ts
@@ -66,6 +66,12 @@ describe('formatTimestampToRelativeTime', () => {
     const tenMinutesAgo = Math.floor(new Date('2024-06-01T12:24:56Z').getTime() / 1000);
     expect(formatTimestampToRelativeTime(tenMinutesAgo)).toBe('10 minutes ago');
   });
+
+  it('formats timestamps under one minute to \"<1 minute ago\"', () => {
+    // 30 seconds ago from the frozen time
+    const thirtySecondsAgo = Math.floor(new Date('2024-06-01T12:34:26Z').getTime() / 1000);
+    expect(formatTimestampToRelativeTime(thirtySecondsAgo)).toBe('<1 minute ago');
+  });
 });
 
 describe('formatTimestamp', () => {

--- a/src/common/utils/time-utils.ts
+++ b/src/common/utils/time-utils.ts
@@ -62,7 +62,13 @@ export function formatTimestamp(
 }
 
 export function formatTimestampToRelativeTime(timestampInSeconds: number): string {
-  const date = new Date(timestampInSeconds * 1000);
-  const relativeTime = formatDistanceToNow(date, { addSuffix: true });
-  return relativeTime;
+  const timestampMs = timestampInSeconds * 1000;
+  const diff = Math.abs(Date.now() - timestampMs);
+
+  if (diff < 60_000) {
+    return '<1 minute ago';
+  }
+
+  const date = new Date(timestampMs);
+  return formatDistanceToNow(date, { addSuffix: true });
 }


### PR DESCRIPTION
This change introduces a concise display for very recent timestamps. formatTimestampToRelativeTime now returns '<1 minute ago' whenever the timestamp is under 60 seconds from the current time; otherwise it falls back to formatDistanceToNow from date-fns. A new test covers this edge case by freezing the clock and verifying that a 30‑second-old timestamp yields '<1 minute ago'.

## Summary
- show `<1 minute ago` for very recent times
- test relative time formatting for 30 sec old timestamp
- remove workplan document

## Testing
- `pnpm lint`
- `pnpm test`
- `pnpm build` *(fails: Failed to fetch fonts)*

closes https://github.com/hirosystems/explorer/issues/2206