### PR TITLE
Remove stacking section from signers page

### DIFF
--- a/src/app/signers/PageClient.tsx
+++ b/src/app/signers/PageClient.tsx
@@ -2,18 +2,17 @@
 
 import { Flex } from '@chakra-ui/react';
 
-import { TokenPrice } from '../../common/types/tokenPrice';
 import { PageTitle } from '../_components/PageTitle';
 import { SignersHeader } from './SignersHeader';
 import SignersTable from './SignersTable';
 
-export default function ({ tokenPrice }: { tokenPrice: TokenPrice }) {
+export default function () {
   return (
     <>
       <Flex justifyContent={'space-between'} alignItems={'flex-end'}>
         <PageTitle>Signers</PageTitle>
       </Flex>
-      <SignersHeader tokenPrice={tokenPrice} />
+      <SignersHeader />
       <SignersTable />
     </>
   );

--- a/src/app/signers/SignersHeader.tsx
+++ b/src/app/signers/SignersHeader.tsx
@@ -1,35 +1,19 @@
-import { Box, Flex, Grid, Icon, Stack } from '@chakra-ui/react';
-import { ArrowRight } from '@phosphor-icons/react';
+import { Box, Grid, Stack } from '@chakra-ui/react';
 import { ReactNode } from 'react';
 
 import { Card } from '../../common/components/Card';
-import { TokenPrice } from '../../common/types/tokenPrice';
-import { Link } from '../../ui/Link';
-import { Text } from '../../ui/Text';
-import { CurrentCycleCard } from './CurrentCycleCard';
-import { NextCycleCard } from './NextCycleCard';
 import { SignersDistribution } from './SignerDistribution';
 import { SignerDistributionHeader } from './SignerDistributionHeader';
 import { SignersMapComponent } from './SignersMapComponent';
-import { StxStackedCard } from './StxStackedCard';
 
 export function SignersHeaderLayout({
-  stackingHeader,
-  currentCycleCard,
-  stxStakedCard,
-  nextCycleCard,
   signerDistributionHeader,
   signerDistribution,
   signersMap,
 }: {
-  stackingHeader: ReactNode;
-  currentCycleCard: ReactNode;
-  stxStakedCard: ReactNode;
-  nextCycleCard: ReactNode;
   signerDistributionHeader: ReactNode;
   signerDistribution: ReactNode;
   signersMap: ReactNode;
-  historicalStackingDataLink: ReactNode;
 }) {
   return (
     <Card width="full" flexDirection="column" gap={4}>
@@ -53,56 +37,16 @@ export function SignersHeaderLayout({
             {signersMap}
           </Box>
         </Grid>
-        <Box
-          width="100%"
-          border="1px solid var(--stacks-colors-border-secondary)"
-          display={['none', 'none', 'none', 'none', 'block']}
-        />
-        <Stack width="full" height="100%" gap={4} pt={7} px={7}>
-          <Flex height={6} alignItems="center">
-            {stackingHeader}
-          </Flex>
-          <Flex
-            flexDirection={['column', 'column', 'row', 'row', 'row']}
-            width="100%"
-            height="100%"
-            gap={4}
-            boxSizing="border-box"
-          >
-            <Flex flex={1}>{currentCycleCard}</Flex>
-            <Flex flex={1}>{stxStakedCard}</Flex>
-            <Flex flex={1}>{nextCycleCard}</Flex>
-          </Flex>
-        </Stack>
       </Stack>
-      {/* {historicalStackingDataLink} TODO: Add back when the stacking page is done */}
     </Card>
   );
 }
 
-export function SignersHeader({ tokenPrice }: { tokenPrice: TokenPrice }) {
+export function SignersHeader() {
   return (
     <SignersHeaderLayout
-      stackingHeader={
-        <Text fontSize="xs" fontWeight="semibold">
-          STACKING
-        </Text>
-      }
-      currentCycleCard={<CurrentCycleCard />}
-      stxStakedCard={<StxStackedCard tokenPrice={tokenPrice} />}
-      nextCycleCard={<NextCycleCard />}
       signerDistributionHeader={<SignerDistributionHeader signerTitle="SIGNER DISTRIBUTION" />}
       signerDistribution={<SignersDistribution />}
-      historicalStackingDataLink={
-        <Flex alignItems="center">
-          <Link href="/" color="textSubdued" fontSize="xs" mr={1}>
-            See Stacking historical data
-          </Link>
-          <Icon h={3} w={3} color="textSubdued">
-            <ArrowRight />
-          </Icon>
-        </Flex>
-      }
       signersMap={<SignersMapComponent />}
     />
   );

--- a/src/app/signers/page.tsx
+++ b/src/app/signers/page.tsx
@@ -1,13 +1,11 @@
 import dynamic from 'next/dynamic';
 
-import { getTokenPrice } from '../getTokenPriceInfo';
 import { SignersPageSkeleton } from './skeleton';
 
 const Page = dynamic(() => import('./PageClient'), {
   loading: () => <SignersPageSkeleton />,
 });
 
-export default async function () {
-  const tokenPrice = await getTokenPrice();
-  return <Page tokenPrice={tokenPrice} />;
+export default function () {
+  return <Page />;
 }

--- a/src/app/signers/skeleton.tsx
+++ b/src/app/signers/skeleton.tsx
@@ -120,13 +120,8 @@ export const SignersDistributionSkeleton = () => (
 
 export const SignersHeaderSkeleton = () => (
   <SignersHeaderLayout
-    stackingHeader={<Skeleton width="30%" height="14px" />}
-    currentCycleCard={<SignersStatsSectionSkeleton />}
-    stxStakedCard={<SignersStatsSectionSkeleton />}
-    nextCycleCard={<SignersStatsSectionSkeleton />}
     signerDistribution={<SignersDistributionSkeleton />}
     signerDistributionHeader={<Skeleton width="30%" height="14px" />}
-    historicalStackingDataLink={<Skeleton width="30%" height="14px" />}
     signersMap={<SignersMapSkeleton />}
   />
 );


### PR DESCRIPTION
**Summary**

- Removed the stacking section from the Signers page so it now focuses solely on signer data. The simplified header is shown in SignersHeader.tsx where only signer distribution and map elements remain
- Updated the skeleton file to match the new layout, ensuring the placeholder header renders only signer distribution data
- Dropped the token price dependency and simplified the client component and route; the page now simply renders <SignersHeader /> without fetching additional data

**Implementation Notes**

- Stacking-related card components were removed from the header layout but kept in the repository for potential reuse.
- Signers page loading states were adjusted to match the trimmed component tree.

The change addresses issue #2222.

**Files Changed**

- src/app/signers/PageClient.tsx
- src/app/signers/SignersHeader.tsx
- src/app/signers/page.tsx
- src/app/signers/skeleton.tsx

**Testing**

-  ✅ pnpm lint (with warnings)
-  ✅ pnpm test:unit
- ❌ pnpm build (failed while downloading fonts in CI due to missing CA certificates)
