### PR TITLE
Clarify network overview tooltip timeframe

### DIFF
--- a/src/app/_components/NetworkOverview/ChartTooltip.tsx
+++ b/src/app/_components/NetworkOverview/ChartTooltip.tsx
@@ -1,3 +1,4 @@
+import { truncateMiddle } from '@/common/utils/utils';
 import { useColorMode } from '@/components/ui/color-mode';
 import { Text } from '@/ui/Text';
 import { Stack } from '@chakra-ui/react';
@@ -59,7 +60,17 @@ export function ChartTooltip({ active, payload, label }: TooltipProps<number, st
               : 'var(--stacks-colors-neutral-sand-100)'
           }
         >
-          {payload[0].value?.toLocaleString()}
+          {payload[0].value?.toLocaleString()} txs
+        </Text>
+        <Text
+          textStyle={'text-medium-xs'}
+          color={
+            colorMode === 'light'
+              ? 'var(--stacks-colors-neutral-sand-200)'
+              : 'var(--stacks-colors-neutral-sand-300)'
+          }
+        >
+          {`In Bitcoin block ${truncateMiddle(dataPoint?.burnBlockHash, 4, 4)}`}
         </Text>
       </Stack>
     );

--- a/src/app/_components/NetworkOverview/NetworkOverview.tsx
+++ b/src/app/_components/NetworkOverview/NetworkOverview.tsx
@@ -1,13 +1,12 @@
 'use client';
 
 import { useHomePageData } from '@/app/context';
-import { ONE_HOUR } from '@/common/queries/query-stale-time';
 import { useColorMode } from '@/components/ui/color-mode';
 import { TabsContent, TabsList, TabsRoot, TabsTrigger } from '@/ui/Tabs';
 import { Text } from '@/ui/Text';
 import { Box, Flex, Stack } from '@chakra-ui/react';
 import { useMemo } from 'react';
-import { Area, AreaChart, CartesianGrid, ResponsiveContainer, Tooltip, XAxis } from 'recharts';
+import { Area, AreaChart, CartesianGrid, ResponsiveContainer, Tooltip } from 'recharts';
 
 import { ChartTooltip } from './ChartTooltip';
 import {
@@ -55,6 +54,8 @@ function NetworkOverviewChart() {
           fullDate: date.toISOString(),
           blocksMined: item.stx_blocks_count,
           dailyTransactions: item.total_tx_count,
+          burnBlockHeight: item.burn_block_height,
+          burnBlockHash: item.burn_block_hash,
         };
       });
   }, [stxBlocksCountPerBtcBlock]);

--- a/src/app/_components/NetworkOverview/__tests__/ChartTooltip.test.tsx
+++ b/src/app/_components/NetworkOverview/__tests__/ChartTooltip.test.tsx
@@ -1,0 +1,28 @@
+import { renderWithProviders } from '@/common/utils/test-utils/render-utils';
+import '@testing-library/jest-dom';
+import { TooltipProps } from 'recharts';
+
+import { ChartTooltip } from '../ChartTooltip';
+
+function renderTooltip(active: boolean = true) {
+  const payload: TooltipProps<number, string>['payload'] = [
+    {
+      value: 42,
+      payload: { date: new Date('2023-01-01T00:00:00Z'), burnBlockHash: '1234567890' },
+    } as any,
+  ];
+  const label = 'Jan 1, 2023';
+  return renderWithProviders(<ChartTooltip active={active} payload={payload} label={label} />);
+}
+
+describe('ChartTooltip', () => {
+  it('renders aggregation interval text when active', () => {
+    const { getByText } = renderTooltip();
+    expect(getByText('In Bitcoin block 1234…7890')).toBeInTheDocument();
+  });
+
+  it('renders nothing when inactive', () => {
+    const { container } = renderTooltip(false);
+    expect(container.firstChild).toBeNull();
+  });
+});

--- a/src/app/data.ts
+++ b/src/app/data.ts
@@ -35,6 +35,8 @@ export interface RecentBlocks {
   btcBlocks: GenericResponseType<UIBtcBlock[]>;
   stxBlocks: GenericResponseType<UIStxBlock[]>;
   stxBlocksCountPerBtcBlock: Array<{
+    burn_block_height: number;
+    burn_block_hash: string;
     burn_block_time: string;
     stx_blocks_count: number;
     total_tx_count: number;
@@ -228,6 +230,8 @@ export async function fetchRecentBlocks(chain: string, api?: string): Promise<Re
   const recentBtcBlockData = btcBlocksData.results.slice(0, RECENT_BTC_BLOCKS_COUNT);
 
   const stxBlocksCountPerBtcBlock = btcBlocksData.results.map((block: BurnBlock) => ({
+    burn_block_height: block.burn_block_height,
+    burn_block_hash: block.burn_block_hash,
     burn_block_time: block.burn_block_time,
     stx_blocks_count: block.stacks_blocks.length,
     total_tx_count: block.total_tx_count,


### PR DESCRIPTION
## Summary
- add explanatory text to Network Overview tooltip
- test ChartTooltip renders new timeframe text

## Issue
Fixes #2215

## Design Decisions
- leverage existing typography and colors for the extra tooltip line
- use renderWithProviders in tests to satisfy cookies/context requirements

## Testing
- `pnpm lint`
- `pnpm test:unit`
- `pnpm build` *(fails: connect EHOSTUNREACH 172.24.0.3:8080)*
