### PR TITLE
fix: show contract deploy filter label

### DIFF
--- a/docs/workplans/BUG-FilterLabelMismatch.md
+++ b/docs/workplans/BUG-FilterLabelMismatch.md
@@ -1,0 +1,21 @@
+Task ID: BUG-FilterLabelMismatch
+Problem Statement: Filter titles on the transactions page do not match dropdown labels; selecting "Contract deploy" shows "Smart contract" in the filter trigger.
+Components Involved: TransactionTypeFilterTriggerText, transactions utils
+Dependencies: None
+Implementation Checklist:
+- [ ] Map transaction type values to labels using existing getTxTypeLabel
+- [ ] Update TransactionTypeFilterTriggerText to use mapping
+- [ ] Add unit tests covering smart_contract label
+- [ ] Ensure dropdown labels match filter titles
+- [ ] Run lint, test, and build commands
+Verification Steps:
+- [ ] pnpm lint
+- [ ] pnpm test:unit
+- [ ] pnpm build
+Decision Authority: Lead engineer may proceed with implementation choices
+Questions/Uncertainties:
+  Blocking: none
+  Non-blocking: none
+Acceptable Tradeoffs: Minimal code changes preferred for clarity
+Status: Completed
+Notes: Using getTxTypeLabel ensures consistent labeling across app.

--- a/src/common/components/table/filters/transaction-type-filter/TransactionTypeFilterTriggerText.tsx
+++ b/src/common/components/table/filters/transaction-type-filter/TransactionTypeFilterTriggerText.tsx
@@ -1,4 +1,4 @@
-import { capitalize } from '@/common/utils/utils';
+import { getTxTypeLabel } from '@/common/utils/transactions';
 
 import { FilterTriggerText } from '../FilterTriggerText';
 
@@ -14,7 +14,7 @@ export function TransactionTypeFilterTriggerText({
   const triggerTextPrefix = areFiltersActive ? 'Type:' : 'Type';
   const firstActiveFilter = transactionType?.[0];
   const firstActiveFilterFormatted = firstActiveFilter
-    ? capitalize(firstActiveFilter.replace(/_/g, ' '))
+    ? getTxTypeLabel(firstActiveFilter)
     : '';
   const otherActiveFilters = transactionType?.slice(1);
   const triggerTextSuffix =

--- a/src/common/components/table/filters/transaction-type-filter/__tests__/TransactionTypeFilterTriggerText.test.tsx
+++ b/src/common/components/table/filters/transaction-type-filter/__tests__/TransactionTypeFilterTriggerText.test.tsx
@@ -1,0 +1,18 @@
+import { renderWithChakraProviders } from '@/common/utils/test-utils/render-utils';
+import '@testing-library/jest-dom';
+import { screen } from '@testing-library/react';
+
+import { TransactionTypeFilterTriggerText } from '../TransactionTypeFilterTriggerText';
+
+describe('TransactionTypeFilterTriggerText', () => {
+  test('displays Contract deploy label when smart_contract filter is active', () => {
+    renderWithChakraProviders(
+      <TransactionTypeFilterTriggerText
+        open={false}
+        defaultTransactionType={['smart_contract']}
+      />
+    );
+    expect(screen.getByText('Contract deploy')).toBeInTheDocument();
+    expect(screen.getByText('Type:')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- map active transaction type labels using `getTxTypeLabel`
- add regression test for contract deploy filter label
- document workplan

## Testing
- `pnpm lint` *(fails: ESLint couldn't find config)*
- `pnpm test:unit` *(fails: jest not found)*
- `pnpm build` *(fails: chakra command not found)*