### PR TITLE
Block Timestamps are different between testnet and mainnet

### DIFF
--- a/docs/workplans/2216-Timestamps.md
+++ b/docs/workplans/2216-Timestamps.md
@@ -1,0 +1,38 @@
+# 2216 - Homepage Block Timestamps
+
+## Problem Statement
+Timestamps in the Recent Blocks widget show values from the previously selected network when switching between mainnet and testnet. Briefly stale data appears until the new network data loads which causes a flicker.
+
+## Components Involved
+- `src/common/queries` hooks fetching block data
+- `src/common/context/GlobalContextProvider`
+- Home page block list components
+
+## Dependencies
+- React Query cache
+- Global network context
+
+## Implementation Checklist
+- [ ] Add active network identifier to query keys of block related hooks
+- [ ] Clear query cache on network change to avoid stale renders
+- [ ] Provide unit tests for query key helpers
+- [ ] Verify lint, unit tests and build succeed
+
+## Verification Steps
+1. Switch between mainnet and testnet and observe that block timestamps update without showing old values.
+2. Automated unit tests pass.
+
+## Decision Authority
+Hiro Systems engineering lead
+
+## Questions / Uncertainties
+None
+
+## Acceptable Tradeoffs
+Clearing the entire query cache on network change may refetch unrelated data but keeps logic simple.
+
+## Status
+In Progress
+
+## Notes
+Initial workplan created by automated agent.

--- a/src/common/context/GlobalContextProvider.tsx
+++ b/src/common/context/GlobalContextProvider.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { useQueryClient } from '@tanstack/react-query';
 import { useSearchParams } from 'next/navigation';
 import { FC, ReactNode, createContext, useCallback, useEffect, useState } from 'react';
 import { useCookies } from 'react-cookie';
@@ -78,6 +79,11 @@ export const GlobalContextProvider: FC<{
     ? btcAddressBaseUrl[0]
     : btcAddressBaseUrl;
   const activeNetworkKey = queryApiUrl || NetworkModeUrlMap[queryNetworkMode];
+
+  const queryClient = useQueryClient();
+  useEffect(() => {
+    queryClient.clear();
+  }, [activeNetworkKey, queryClient]);
 
   const addedCustomNetworks: Record<string, Network> = JSON.parse(
     addedCustomNetworksCookie || '{}'

--- a/src/common/context/__tests__/GlobalContext.test.tsx
+++ b/src/common/context/__tests__/GlobalContext.test.tsx
@@ -4,6 +4,7 @@ import { useContext } from 'react';
 import { CookiesProvider } from 'react-cookie';
 
 import { fetchCustomNetworkId } from '../../components/modals/AddNetwork/utils';
+import { QueryProvider } from '../../utils/test-utils/render-utils';
 import { GlobalContext, GlobalContextProvider } from '../GlobalContextProvider';
 
 const useSearchParams = useSearchParamsActual as jest.MockedFunction<typeof useSearchParamsActual>;
@@ -56,11 +57,13 @@ describe('GlobalContext', () => {
       },
     } as any);
     render(
-      <CookiesProvider>
-        <GlobalContextProvider addedCustomNetworksCookie={''} removedCustomNetworksCookie={''}>
-          <GlobalContextTestComponent />
-        </GlobalContextProvider>
-      </CookiesProvider>
+      <QueryProvider>
+        <CookiesProvider>
+          <GlobalContextProvider addedCustomNetworksCookie={''} removedCustomNetworksCookie={''}>
+            <GlobalContextTestComponent />
+          </GlobalContextProvider>
+        </CookiesProvider>
+      </QueryProvider>
     );
 
     expect(screen.getByText('Global Context Test')).toBeInTheDocument();
@@ -75,11 +78,13 @@ describe('GlobalContext', () => {
       },
     } as any);
     render(
-      <CookiesProvider>
-        <GlobalContextProvider addedCustomNetworksCookie={''} removedCustomNetworksCookie={''}>
-          <GlobalContextTestComponent />
-        </GlobalContextProvider>
-      </CookiesProvider>
+      <QueryProvider>
+        <CookiesProvider>
+          <GlobalContextProvider addedCustomNetworksCookie={''} removedCustomNetworksCookie={''}>
+            <GlobalContextTestComponent />
+          </GlobalContextProvider>
+        </CookiesProvider>
+      </QueryProvider>
     );
 
     const networks = getContextField('networks');

--- a/src/common/queries/__tests__/useBlockListInfinite.test.ts
+++ b/src/common/queries/__tests__/useBlockListInfinite.test.ts
@@ -1,0 +1,8 @@
+import { getBlockListQueryKey } from '../useBlockListInfinite';
+
+describe('getBlockListQueryKey', () => {
+  it('constructs a key with network identifier', () => {
+    const key = getBlockListQueryKey(10, 'testnet');
+    expect(key).toEqual(['blockListInfinite', 10, 'testnet']);
+  });
+});

--- a/src/common/queries/__tests__/useBlocksByBurnBlock.test.ts
+++ b/src/common/queries/__tests__/useBlocksByBurnBlock.test.ts
@@ -1,0 +1,8 @@
+import { getBlocksByBurnBlockQueryKey } from '../useBlocksByBurnBlock';
+
+describe('getBlocksByBurnBlockQueryKey', () => {
+  it('constructs a key with network identifier', () => {
+    const key = getBlocksByBurnBlockQueryKey('123', 'net', 'range', 'ext');
+    expect(key).toEqual(['getBlocksByBurnBlock', '123', 'net', 'range', 'ext']);
+  });
+});

--- a/src/common/queries/__tests__/useBurnBlocksInfinite.test.ts
+++ b/src/common/queries/__tests__/useBurnBlocksInfinite.test.ts
@@ -1,0 +1,13 @@
+import { getBurnBlocksQueryKey } from '../useBurnBlocksInfinite';
+
+describe('getBurnBlocksQueryKey', () => {
+  it('includes network identifier', () => {
+    const key = getBurnBlocksQueryKey(5, 'https://api.hiro.so');
+    expect(key).toEqual(['burnBlocks', 5, 'https://api.hiro.so']);
+  });
+
+  it('handles query key extension', () => {
+    const key = getBurnBlocksQueryKey(3, 'net', 'extra');
+    expect(key).toEqual(['burnBlocks', 3, 'net', 'extra']);
+  });
+});

--- a/src/common/queries/useBlockByHash.ts
+++ b/src/common/queries/useBlockByHash.ts
@@ -4,13 +4,21 @@ import { Block } from '@stacks/stacks-blockchain-api-types';
 
 import { callApiWithErrorHandling } from '../../api/callApiWithErrorHandling';
 import { useApiClient } from '../../api/useApiClient';
+import { useGlobalContext } from '../context/useGlobalContext';
 
 const BLOCK_QUERY_KEY = 'block';
 
+const getBlockByHashQueryKey = (hash: string | undefined, activeNetworkKey: string) => [
+  'blockByHash',
+  hash,
+  activeNetworkKey,
+];
+
 export function useBlockByHash(hash?: string, options: any = {}) {
   const apiClient = useApiClient();
+  const { activeNetworkKey } = useGlobalContext();
   return useQuery<Block>({
-    queryKey: ['blockByHash', hash],
+    queryKey: getBlockByHashQueryKey(hash, activeNetworkKey),
     queryFn: async () => {
       if (!hash) return undefined;
       return (await callApiWithErrorHandling(apiClient, '/extended/v2/blocks/{height_or_hash}', {
@@ -25,9 +33,10 @@ export function useBlockByHash(hash?: string, options: any = {}) {
 
 export function useSuspenseBlockByHeightOrHash(heightOrHash: string) {
   const apiClient = useApiClient();
+  const { activeNetworkKey } = useGlobalContext();
   if (!heightOrHash) throw new Error('Height or hash is required');
   return useSuspenseQuery({
-    queryKey: [BLOCK_QUERY_KEY, heightOrHash],
+    queryKey: [BLOCK_QUERY_KEY, heightOrHash, activeNetworkKey],
     queryFn: async () => {
       if (!heightOrHash) return undefined;
       return await callApiWithErrorHandling(apiClient, '/extended/v2/blocks/{height_or_hash}', {

--- a/src/common/queries/useBlockListInfinite.ts
+++ b/src/common/queries/useBlockListInfinite.ts
@@ -10,16 +10,24 @@ import { Block } from '@stacks/stacks-blockchain-api-types';
 import { callApiWithErrorHandling } from '../../api/callApiWithErrorHandling';
 import { useApiClient } from '../../api/useApiClient';
 import { DEFAULT_LIST_LIMIT } from '../constants/constants';
+import { useGlobalContext } from '../context/useGlobalContext';
 import { GenericResponseType } from '../hooks/useInfiniteQueryResult';
 import { getNextPageParam } from '../utils/utils';
 import { TWO_MINUTES } from './query-stale-time';
 
 export const BLOCK_LIST_QUERY_KEY = 'blockListInfinite';
 
+export const getBlockListQueryKey = (limit: number, activeNetworkKey: string) => [
+  BLOCK_LIST_QUERY_KEY,
+  limit,
+  activeNetworkKey,
+];
+
 export const useSuspenseBlockListInfinite = (limit = DEFAULT_LIST_LIMIT) => {
   const apiClient = useApiClient();
+  const { activeNetworkKey } = useGlobalContext();
   return useSuspenseInfiniteQuery({
-    queryKey: [BLOCK_LIST_QUERY_KEY, limit],
+    queryKey: getBlockListQueryKey(limit, activeNetworkKey),
     queryFn: async ({ pageParam }: { pageParam: number }) => {
       return await callApiWithErrorHandling(apiClient, '/extended/v1/block/', {
         params: { query: { limit, offset: pageParam || 0 } },
@@ -33,8 +41,9 @@ export const useSuspenseBlockListInfinite = (limit = DEFAULT_LIST_LIMIT) => {
 
 export const useBlockListInfinite = (limit = DEFAULT_LIST_LIMIT) => {
   const apiClient = useApiClient();
+  const { activeNetworkKey } = useGlobalContext();
   return useInfiniteQuery({
-    queryKey: [BLOCK_LIST_QUERY_KEY, limit],
+    queryKey: getBlockListQueryKey(limit, activeNetworkKey),
     queryFn: async ({ pageParam }: { pageParam: number }) => {
       return await callApiWithErrorHandling(apiClient, '/extended/v1/block/', {
         params: { query: { limit, offset: pageParam || 0 } },
@@ -51,8 +60,9 @@ export const useBlockList = (
   options?: any
 ): UseQueryResult<GenericResponseType<Block>> => {
   const apiClient = useApiClient();
+  const { activeNetworkKey } = useGlobalContext();
   return useQuery({
-    queryKey: [BLOCK_LIST_QUERY_KEY, limit],
+    queryKey: getBlockListQueryKey(limit, activeNetworkKey),
     queryFn: async () => {
       return await callApiWithErrorHandling(apiClient, '/extended/v1/block/', {
         params: { query: { limit } },

--- a/src/common/queries/useBlocksByBurnBlock.ts
+++ b/src/common/queries/useBlocksByBurnBlock.ts
@@ -10,22 +10,37 @@ import { NakamotoBlock } from '@stacks/blockchain-api-client';
 
 import { callApiWithErrorHandling } from '../../api/callApiWithErrorHandling';
 import { useApiClient } from '../../api/useApiClient';
+import { useGlobalContext } from '../context/useGlobalContext';
 import { GenericResponseType } from '../hooks/useInfiniteQueryResult';
 import { getNextPageParam } from '../utils/utils';
 import { ONE_SECOND, TWO_MINUTES } from './query-stale-time';
 
 export const GET_BLOCKS_BY_BURN_BLOCK_QUERY_KEY = 'getBlocksByBurnBlock';
 
+export const getBlocksByBurnBlockQueryKey = (
+  heightOrHash: string | number,
+  activeNetworkKey: string,
+  rangeQueryKey?: string,
+  queryKeyExtension?: string
+) => [
+  GET_BLOCKS_BY_BURN_BLOCK_QUERY_KEY,
+  heightOrHash,
+  activeNetworkKey,
+  rangeQueryKey,
+  queryKeyExtension,
+];
+
 export const MAX_STX_BLOCKS_PER_BURN_BLOCK_LIMIT = 30;
 
 export function useGetStxBlocksByBurnBlockQuery() {
   const apiClient = useApiClient();
+  const { activeNetworkKey } = useGlobalContext();
 
   return (
     heightOrHash: string | number,
     numStxBlocksPerBtcBlock: number = MAX_STX_BLOCKS_PER_BURN_BLOCK_LIMIT
   ) => ({
-    queryKey: [GET_BLOCKS_BY_BURN_BLOCK_QUERY_KEY, heightOrHash, 'special'],
+    queryKey: getBlocksByBurnBlockQueryKey(heightOrHash, activeNetworkKey, 'special'),
     queryFn: async () => {
       if (!heightOrHash) return undefined;
       return await callApiWithErrorHandling(
@@ -53,9 +68,15 @@ export function useBlocksByBurnBlock(
   queryKeyExtension?: string
 ): UseInfiniteQueryResult<InfiniteData<GenericResponseType<NakamotoBlock>>> {
   const apiClient = useApiClient();
+  const { activeNetworkKey } = useGlobalContext();
   const rangeQueryKey = offset ? `${offset}-${offset + limit}` : '';
   return useInfiniteQuery({
-    queryKey: [GET_BLOCKS_BY_BURN_BLOCK_QUERY_KEY, heightOrHash, rangeQueryKey, queryKeyExtension],
+    queryKey: getBlocksByBurnBlockQueryKey(
+      heightOrHash,
+      activeNetworkKey,
+      rangeQueryKey,
+      queryKeyExtension
+    ),
     queryFn: async ({ pageParam }: { pageParam: number }) => {
       if (!heightOrHash) return undefined;
       return await callApiWithErrorHandling(
@@ -80,8 +101,14 @@ export function useSuspenseBlocksByBurnBlock(
   queryKeyExtension?: string
 ): UseSuspenseInfiniteQueryResult<InfiniteData<GenericResponseType<NakamotoBlock>>> {
   const apiClient = useApiClient();
+  const { activeNetworkKey } = useGlobalContext();
   return useSuspenseInfiniteQuery({
-    queryKey: [GET_BLOCKS_BY_BURN_BLOCK_QUERY_KEY, heightOrHash, queryKeyExtension],
+    queryKey: getBlocksByBurnBlockQueryKey(
+      heightOrHash,
+      activeNetworkKey,
+      undefined,
+      queryKeyExtension
+    ),
     queryFn: async ({ pageParam }: { pageParam: number }) => {
       if (!heightOrHash) return undefined;
       return await callApiWithErrorHandling(

--- a/src/common/queries/useBurnBlock.ts
+++ b/src/common/queries/useBurnBlock.ts
@@ -10,17 +10,25 @@ import { BurnBlock } from '@stacks/blockchain-api-client';
 
 import { callApiWithErrorHandling } from '../../api/callApiWithErrorHandling';
 import { useApiClient } from '../../api/useApiClient';
+import { useGlobalContext } from '../context/useGlobalContext';
 
 export const BURN_BLOCKS_QUERY_KEY = 'burnBlocks';
+
+export const getBurnBlockQueryKey = (heightOrHash: string | number, activeNetworkKey: string) => [
+  'burn-block',
+  heightOrHash,
+  activeNetworkKey,
+];
 
 export function useFetchBurnBlock(): (
   heightOrHash: string | number
 ) => Promise<BurnBlock | undefined> {
   const apiClient = useApiClient();
+  const { activeNetworkKey } = useGlobalContext();
   const queryClient = useQueryClient();
 
   return async (heightOrHash: string | number) => {
-    const queryKey = [BURN_BLOCKS_QUERY_KEY, heightOrHash];
+    const queryKey = getBurnBlockQueryKey(heightOrHash, activeNetworkKey);
 
     const cachedData = queryClient.getQueryData<BurnBlock>(queryKey);
     if (cachedData) {
@@ -66,8 +74,9 @@ export function useBurnBlock(
   options: any = {}
 ): UseQueryResult<BurnBlock> {
   const apiClient = useApiClient();
+  const { activeNetworkKey } = useGlobalContext();
   return useQuery({
-    queryKey: ['burn-block', heightOrHash],
+    queryKey: getBurnBlockQueryKey(heightOrHash, activeNetworkKey),
     queryFn: async () => {
       if (!heightOrHash) return undefined;
       return await callApiWithErrorHandling(
@@ -88,8 +97,9 @@ export function useSuspenseBurnBlock(
   options: any = {}
 ): UseSuspenseQueryResult<BurnBlock> {
   const apiClient = useApiClient();
+  const { activeNetworkKey } = useGlobalContext();
   return useSuspenseQuery({
-    queryKey: ['burn-block', heightOrHash],
+    queryKey: getBurnBlockQueryKey(heightOrHash, activeNetworkKey),
     queryFn: async () => {
       if (!heightOrHash) return undefined;
       return await callApiWithErrorHandling(

--- a/src/common/queries/useBurnBlocksInfinite.ts
+++ b/src/common/queries/useBurnBlocksInfinite.ts
@@ -13,11 +13,21 @@ import { BurnBlock } from '@stacks/blockchain-api-client';
 import { callApiWithErrorHandling } from '../../api/callApiWithErrorHandling';
 import { useApiClient } from '../../api/useApiClient';
 import { DEFAULT_BURN_BLOCKS_LIMIT } from '../constants/constants';
+import { useGlobalContext } from '../context/useGlobalContext';
 import { GenericResponseType } from '../hooks/useInfiniteQueryResult';
 import { getNextPageParam } from '../utils/utils';
 import { TWO_MINUTES } from './query-stale-time';
 
 export const BURN_BLOCKS_QUERY_KEY = 'burnBlocks';
+
+export const getBurnBlocksQueryKey = (
+  limit: number,
+  activeNetworkKey: string,
+  queryKeyExtension?: string
+) =>
+  queryKeyExtension
+    ? [BURN_BLOCKS_QUERY_KEY, limit, activeNetworkKey, queryKeyExtension]
+    : [BURN_BLOCKS_QUERY_KEY, limit, activeNetworkKey];
 
 export function useBurnBlocksInfinite(
   limit = DEFAULT_BURN_BLOCKS_LIMIT,
@@ -25,10 +35,9 @@ export function useBurnBlocksInfinite(
   queryKeyExtension?: string
 ): UseInfiniteQueryResult<InfiniteData<GenericResponseType<BurnBlock>>> {
   const apiClient = useApiClient();
+  const { activeNetworkKey } = useGlobalContext();
   return useInfiniteQuery({
-    queryKey: queryKeyExtension
-      ? [BURN_BLOCKS_QUERY_KEY, limit, queryKeyExtension]
-      : [BURN_BLOCKS_QUERY_KEY, limit],
+    queryKey: getBurnBlocksQueryKey(limit, activeNetworkKey, queryKeyExtension),
     queryFn: async ({ pageParam }: { pageParam: number }) => {
       return await callApiWithErrorHandling(apiClient, '/extended/v2/burn-blocks/', {
         params: { query: { limit, offset: pageParam } },
@@ -47,10 +56,9 @@ export function useSuspenseBurnBlocks(
   queryKeyExtension?: string
 ): UseSuspenseInfiniteQueryResult<InfiniteData<GenericResponseType<BurnBlock>>> {
   const apiClient = useApiClient();
+  const { activeNetworkKey } = useGlobalContext();
   return useSuspenseInfiniteQuery({
-    queryKey: queryKeyExtension
-      ? [BURN_BLOCKS_QUERY_KEY, limit, queryKeyExtension]
-      : [BURN_BLOCKS_QUERY_KEY, limit],
+    queryKey: getBurnBlocksQueryKey(limit, activeNetworkKey, queryKeyExtension),
     queryFn: async ({ pageParam }: { pageParam: number }) => {
       return await callApiWithErrorHandling(apiClient, '/extended/v2/burn-blocks/', {
         params: { query: { limit, offset: pageParam } },
@@ -70,10 +78,12 @@ export function useBurnBlocks(
   queryKeyExtension?: string
 ): UseQueryResult<GenericResponseType<BurnBlock>> {
   const apiClient = useApiClient();
+  const { activeNetworkKey } = useGlobalContext();
   return useQuery({
     queryKey: [
       BURN_BLOCKS_QUERY_KEY,
       limit,
+      activeNetworkKey,
       ...(offset ? [offset] : []),
       ...(queryKeyExtension ? [queryKeyExtension] : []),
     ],


### PR DESCRIPTION
## Problems
- Timestamps in recent blocks widget are inconsistent between mainnet and testnet
- When switching between mainnet and testnet, timstamps flash before updating

## Summary
- Cleared the React Query cache whenever the active network changes, preventing stale block data from appearing after a network switch
- Introduced a helper to build query keys with the active network identifier, ensuring per-network caching for burn block requests
- Added unit tests verifying that the generated query keys include the active network identifier to guard against regressions

## Testing
- `pnpm lint`
- `pnpm test:unit`
- `pnpm build` *(fails: Failed to fetch `Instrument Sans` from Google Fonts)*

Fixes: https://github.com/hirosystems/explorer/issues/2216
