### PR TITLE
fix: change result item bg color on hover

### DIFF
--- a/src/app/_components/Search/ResultItem.tsx
+++ b/src/app/_components/Search/ResultItem.tsx
@@ -40,7 +40,7 @@ function ResultItemWrapper({ children, ...props }: FlexProps) {
       justifyContent={'space-between'}
       cursor={'pointer'}
       _hover={{
-        background: 'surfaceSecondary',
+        background: 'surfaceFifth',
       }}
       {...props}
     >


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
The current effect removes the background on hover, which feels broken.
Proposal: use surface-fifth from the design system as the hover background to keep it consistent and readable.

## Issue ticket number and link
closes https://github.com/hirosystems/explorer/issues/2260
