### PR TITLE
fix: recent block links do not open a new tab

### DIFF
--- a/src/app/_components/RecentBlocks/BtcBlock.tsx
+++ b/src/app/_components/RecentBlocks/BtcBlock.tsx
@@ -33,7 +33,6 @@ export function BtcBlock({ burnBlock }: { burnBlock: BurnBlock }) {
     >
       <Link
         href={buildUrl(`/btcblock/${burnBlock.burn_block_hash}`, network)}
-        target={'_blank'}
         _hover={{ textDecoration: 'none' }}
         aria-label={`Bitcoin block ${burnBlock.burn_block_height} mined at ${
           burnBlock.burn_block_time
@@ -136,7 +135,6 @@ export function NewestBtcBlock({ burnBlock }: { burnBlock: BurnBlock }) {
     >
       <Link
         href={buildUrl(`/btcblock/${burnBlock.burn_block_hash}`, network)}
-        target={'_blank'}
         rel="noreferrer"
         _hover={{ textDecoration: 'none' }}
         aria-label={`Newest Bitcoin block ${burnBlock.burn_block_height} mined at ${burnBlock.burn_block_time} with ${burnBlock.stacks_blocks.length} Stacks blocks`}

--- a/src/app/_components/RecentBlocks/StxBlock.tsx
+++ b/src/app/_components/RecentBlocks/StxBlock.tsx
@@ -65,7 +65,6 @@ export function StxBlockGroup({
           <Link
             href={buildUrl(`/btcblock/${stxBlocks[0].burn_block_hash}`, network)}
             _hover={{ textDecoration: 'none' }}
-            target={'_blank'}
           >
             <HStack
               separator={
@@ -143,7 +142,6 @@ export function StxBlock({ stxBlock }: { stxBlock: UIStxBlock }) {
     >
       <Link
         href={buildUrl(`/block/${stxBlock.hash}`, network)}
-        target={'_blank'}
         rel="noreferrer"
         _hover={{ textDecoration: 'none' }}
       >
@@ -246,7 +244,6 @@ export function NewestStxBlock({ stxBlock }: { stxBlock: UIStxBlock }) {
     >
       <Link
         href={buildUrl(`/block/${stxBlock.hash}`, network)}
-        target={'_blank'}
         rel="noreferrer"
         _hover={{ textDecoration: 'none' }}
       >


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [ ] Refactor
- [ ] Feature
- [X] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
Fixing recent blocks links so they do not open a new tab 

## Issue ticket number and link
closes https://github.com/hirosystems/explorer/issues/2199

# Checklist:
- [X] I have performed a self-review of my code.
- [X] I have tested the change on desktop and mobile.
- [ ] I have added thorough tests where applicable.
- [ ] I've added analytics and error logging where applicable.

## Screenshots (if appropriate):
<!--- Add screenshots of your changes -->
