### PR TITLE
fix: remove duplicated border in pagination control

### DIFF
--- a/src/common/components/table/TablePaginationControls.tsx
+++ b/src/common/components/table/TablePaginationControls.tsx
@@ -118,7 +118,6 @@ export function TablePaginationControls({
         h="auto"
         alignSelf="stretch"
         borderColor="redesignBorderSecondary"
-        borderWidth="1px"
       />
 
       <Flex gap={4} px={4} py={{ base: 3, lg: 2 }} alignItems="center" justifyContent="center">


### PR DESCRIPTION

Removed double border line in the pagination control

| Before | After |
|--------|--------|
| <img width="191" alt="Screenshot 2025-05-30 at 17 30 00" src="https://github.com/user-attachments/assets/f6053e6f-7ed0-45ee-9bf9-68f3cbd4d219" /> | <img width="190" alt="Screenshot 2025-05-30 at 17 30 13" src="https://github.com/user-attachments/assets/8d7ee449-4817-4366-9ad2-8c2aa180039a" /> |
