### PR TITLE
chore: add mockdata and display sponsor address in transaction detail…

### DIFF
--- a/src/app/txid/[txId]/SmartContract/SmartContractTx.tsx
+++ b/src/app/txid/[txId]/SmartContract/SmartContractTx.tsx
@@ -20,7 +20,7 @@ export function SmartContractTx({
 }) {
   const txContractId = getTxContractId(tx);
   const { data: contract } = useContractById(txContractId);
-  const source = contract?.source_code;
+  const source = contract?.source_code || (tx as any)?.smart_contract?.source_code;
 
   return (
     <TxPage tx={tx} contractId={txContractId} txDetails={<TxDetails tx={tx} />}>

--- a/src/app/txid/[txId]/TxDetails/Fees.tsx
+++ b/src/app/txid/[txId]/TxDetails/Fees.tsx
@@ -13,6 +13,9 @@ import { microToStacksFormatted } from '../../../../common/utils/utils';
 
 export const Fees: FC<{ tx: Transaction | MempoolTransaction }> = ({ tx }) => {
   const stxValue = microToStacksFormatted(tx.fee_rate);
+  const sponsorText =
+    tx.sponsored && tx.sponsor_address ? ` (sponsored by ${tx.sponsor_address})` : '';
+  const fullCopyValue = `${stxValue} STX${sponsorText}`;
   return (
     <KeyValueHorizontal
       label={'Fees'}
@@ -22,14 +25,17 @@ export const Fees: FC<{ tx: Transaction | MempoolTransaction }> = ({ tx }) => {
             <Value>{stxValue} STX</Value>
             <StxPriceButton tx={tx} value={Number(tx.fee_rate)} />
           </Flex>
-          {tx.sponsored ? (
-            <Badge ml={4} color={'text'}>
-              Sponsored
-            </Badge>
-          ) : null}
+          {tx.sponsored && (
+            <Flex alignItems={'center'}>
+              <Badge ml={4} color="text" mr={4}>
+                Sponsored By
+              </Badge>
+              <Value>{tx.sponsor_address}</Value>
+            </Flex>
+          )}
         </Flex>
       }
-      copyValue={stxValue.toString()}
+      copyValue={fullCopyValue.toString()}
     />
   );
 };

--- a/src/common/mockData/txsData.ts
+++ b/src/common/mockData/txsData.ts
@@ -108,7 +108,7 @@ export const mockSponsoredTx = {
   execution_cost_write_count: 0,
   execution_cost_write_length: 0,
   events: [],
-  tx_type: 'smart_contract',
+  tx_type: 'token_transfer',
   token_transfer: {
     recipient_address: 'SP3XXK8BG5X7CRH7W07RRJK3JZJXJ799WX3Y0SMCR',
     amount: '1',

--- a/src/common/mockData/txsData.ts
+++ b/src/common/mockData/txsData.ts
@@ -69,3 +69,67 @@ export const addressBalanceMockData = {
     balance: '1987654',
   },
 };
+
+export const mockSponsoredTx = {
+  tx_id: '0x438405f60647aa3dcada6997e0815f648d6e87bbcf50db5bb71633739e7a17c5',
+  nonce: 630813,
+  fee_rate: '300',
+  sender_address: 'ST2TFVBMRPS5SSNP98DQKQ5JNB2B6NZM91C4K3P7B',
+  sponsored: true,
+  sponsor_address: 'SP2C2K8XYZFAKEADDRESS',
+  post_condition_mode: 'deny',
+  post_conditions: [],
+  anchor_mode: 'any',
+  block_hash: '0x438405f60647aa3dcada6997e0815f648d6e87bbcf50db5bb71633739e7a17c5',
+  block_height: 1936631,
+  block_time: 1748853614,
+  block_time_iso: '2025-06-02T08:40:14.000Z',
+  burn_block_time: 1748853352,
+  burn_block_height: 53537,
+  burn_block_time_iso: '2025-06-02T08:35:52.000Z',
+  parent_burn_block_time: 1748853352,
+  parent_burn_block_time_iso: '2025-06-02T08:35:52.000Z',
+  canonical: true,
+  tx_index: 0,
+  tx_status: 'success',
+  tx_result: {
+    hex: '0x0703',
+    repr: '(ok true)',
+  },
+  event_count: 1,
+  parent_block_hash: '0x3ab23b8843ee2cc37874acce70559ad6232d7468d22027c86eaa5e3b6bbcbdc9',
+  is_unanchored: false,
+  microblock_hash: '0x',
+  microblock_sequence: 2147483647,
+  microblock_canonical: true,
+  execution_cost_read_count: 0,
+  execution_cost_read_length: 0,
+  execution_cost_runtime: 0,
+  execution_cost_write_count: 0,
+  execution_cost_write_length: 0,
+  events: [],
+  tx_type: 'smart_contract',
+  token_transfer: {
+    recipient_address: 'SP3XXK8BG5X7CRH7W07RRJK3JZJXJ799WX3Y0SMCR',
+    amount: '1',
+    memo: '0x00000000000000000000000000000000000000000000000000000000000000000000',
+  },
+  smart_contract: {
+    contract_id: 'ST2TFVBMRPS5SSNP98DQKQ5JNB2B6NZM91C4K3P7B.my-awesome-contract',
+    source_code: `
+      (define-public (hello-world)
+        (ok "Hello from mock contract"))
+    `,
+  },
+  contract_call: {
+    contract_id: 'ST2TFVBMRPS5SSNP98DQKQ5JNB2B6NZM91C4K3P7B.my-awesome-contract',
+    function_name: 'transferTokens',
+    function_signature: '(define-public (transferTokens))',
+    function_args: [],
+  },
+  tenure_change: {
+    old_tenure: '6 months',
+    new_tenure: '12 months',
+    reason: 'User upgraded subscription',
+  },
+};

--- a/src/common/queries/useTxById.ts
+++ b/src/common/queries/useTxById.ts
@@ -9,6 +9,7 @@ import { MempoolTransaction, Transaction } from '@stacks/stacks-blockchain-api-t
 
 import { callApiWithErrorHandling } from '../../api/callApiWithErrorHandling';
 import { useApiClient } from '../../api/useApiClient';
+import { mockSponsoredTx } from '../../common/mockData/txsData';
 import { DEFAULT_TX_EVENTS_LIMIT } from '../constants/constants';
 
 export function useTxById(
@@ -42,6 +43,13 @@ export function useSuspenseTxById(
     queryKey: ['txById', txId],
     queryFn: async () => {
       if (!txId) return undefined;
+      //Return mock if it matches
+      if (txId === mockSponsoredTx.tx_id) {
+        console.log('Returning mockSponsoredTx');
+        return mockSponsoredTx;
+      }
+
+      //Otherwise call real API
       return await callApiWithErrorHandling(apiClient, '/extended/v1/tx/{tx_id}', {
         params: {
           path: { tx_id: txId },

--- a/src/features/txs-list/ConfirmedTxsList.tsx
+++ b/src/features/txs-list/ConfirmedTxsList.tsx
@@ -31,7 +31,7 @@ function ConfirmedTxsListBase({
 }: ConfirmedTxsListProps) {
   const response = useConfirmedTransactionsInfinite(filters);
   const txs = useInfiniteQueryResult<Transaction>(response, limit);
-
+  console.log('txs', txs);
   return (
     <Box pb={6}>
       {!!filters && (

--- a/src/features/txs-list/ConfirmedTxsList.tsx
+++ b/src/features/txs-list/ConfirmedTxsList.tsx
@@ -31,7 +31,7 @@ function ConfirmedTxsListBase({
 }: ConfirmedTxsListProps) {
   const response = useConfirmedTransactionsInfinite(filters);
   const txs = useInfiniteQueryResult<Transaction>(response, limit);
-  console.log('txs', txs);
+
   return (
     <Box pb={6}>
       {!!filters && (


### PR DESCRIPTION
…s #1955

## What type of PR is this? (check all applicable)
- [ ] Refactor
- [x ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
This PR adds mocked data for sponsored transactions with the `sponsored: true` flag to help test and visualize sponsored transactions in the Stacks Explorer UI.
Currently, the real API does not return any transactions marked as `sponsored: true`, making it difficult to develop and validate the frontend behavior. To solve this, mock data was created and injected into the transaction list, including the `sponsored address` in the `fees` component.

## Issue ticket number and link
https://github.com/hirosystems/explorer/issues/1955

# Checklist:
- [x] I have performed a self-review of my code.
- [x] I have tested the change on desktop and mobile.
- [ ] I have added thorough tests where applicable.
- [ ] I've added analytics and error logging where applicable.

## Screenshots (if appropriate):
<img width="1057" alt="Screenshot 2025-06-06 at 5 25 20 PM" src="https://github.com/user-attachments/assets/7d5eca89-3625-403e-a416-35ba9fd32b63" />

