### PR TITLE
feat: add sponsored address on fees tsx

### DIFF
--- a/src/app/txid/[txId]/TxDetails/Fees.tsx
+++ b/src/app/txid/[txId]/TxDetails/Fees.tsx
@@ -13,6 +13,9 @@ import { microToStacksFormatted } from '../../../../common/utils/utils';
 
 export const Fees: FC<{ tx: Transaction | MempoolTransaction }> = ({ tx }) => {
   const stxValue = microToStacksFormatted(tx.fee_rate);
+  const sponsorText =
+    tx.sponsored && tx.sponsor_address ? ` (sponsored by ${tx.sponsor_address})` : '';
+  const fullCopyValue = `${stxValue} ${sponsorText}`;
   return (
     <KeyValueHorizontal
       label={'Fees'}
@@ -22,14 +25,17 @@ export const Fees: FC<{ tx: Transaction | MempoolTransaction }> = ({ tx }) => {
             <Value>{stxValue} STX</Value>
             <StxPriceButton tx={tx} value={Number(tx.fee_rate)} />
           </Flex>
-          {tx.sponsored ? (
-            <Badge ml={4} color={'text'}>
-              Sponsored
-            </Badge>
-          ) : null}
+          {tx.sponsored && (
+            <Flex alignItems={'center'}>
+              <Badge ml={4} color="text" mr={4}>
+                Sponsored By
+              </Badge>
+              <Value>{tx.sponsor_address}</Value>
+            </Flex>
+          )}
         </Flex>
       }
-      copyValue={stxValue.toString()}
+      copyValue={fullCopyValue.toString()}
     />
   );
 };


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
This PR adds a sponsored address inside of fees component when the sponsored is "true", the sponsored address will appear inside the fees block.
Additionally, the "Copy Fees" functionality now includes the sponsored address when present, providing a complete value for sponsored transactions.

## Issue ticket number and link
https://github.com/hirosystems/explorer/issues/1955

# Checklist:
- [x] I have performed a self-review of my code.
- [x] I have tested the change on desktop and mobile.
- [ ] I have added thorough tests where applicable.
- [ ] I've added analytics and error logging where applicable.

## Screenshots (if appropriate):
<img width="1057" alt="Screenshot 2025-06-06 at 5 25 20 PM" src="https://github.com/user-attachments/assets/17266d2a-dfb9-4656-9d01-f6275a2d0509" />

