### PR TITLE
fix: switch recent block timestamps to relative time

### DIFF
--- a/src/app/_components/RecentBlocks/BtcBlock.tsx
+++ b/src/app/_components/RecentBlocks/BtcBlock.tsx
@@ -1,4 +1,4 @@
-import { formatTimestampTo12HourTime } from '@/common/utils/time-utils';
+import { formatTimestampToRelativeTime } from '@/common/utils/time-utils';
 import { Flex, HStack, Icon, Stack } from '@chakra-ui/react';
 import { CaretRight } from '@phosphor-icons/react';
 
@@ -34,9 +34,9 @@ export function BtcBlock({ burnBlock }: { burnBlock: BurnBlock }) {
       <Link
         href={buildUrl(`/btcblock/${burnBlock.burn_block_hash}`, network)}
         _hover={{ textDecoration: 'none' }}
-        aria-label={`Bitcoin block ${burnBlock.burn_block_height} mined at ${
+        aria-label={`Bitcoin block ${formatTimestampToRelativeTime(burnBlock.burn_block_height)} mined at ${formatTimestampToRelativeTime(
           burnBlock.burn_block_time
-        } with ${burnBlock.stacks_blocks.length} Stacks blocks`}
+        )} with ${burnBlock.stacks_blocks.length} Stacks blocks`}
         role="listitem"
         tabIndex={0}
       >
@@ -84,10 +84,7 @@ export function BtcBlock({ burnBlock }: { burnBlock: BurnBlock }) {
                 aria-label={`Block timestamp: ${burnBlock.burn_block_time}`}
                 suppressHydrationWarning
               >
-                {formatTimestampTo12HourTime(burnBlock.burn_block_time, {
-                  useLocalTime: true,
-                  includeSeconds: true,
-                })}
+                {formatTimestampToRelativeTime(burnBlock.burn_block_time)}
               </Text>
             </Stack>
             <HStack gap={1.5} p={2} borderRadius={'redesign.md'} bg={'surfaceSecondary'}>
@@ -208,13 +205,10 @@ export function NewestBtcBlock({ burnBlock }: { burnBlock: BurnBlock }) {
                   <Text
                     textStyle={'text-medium-xs'}
                     color={'textSecondary'}
-                    aria-label={`Block timestamp: ${burnBlock.burn_block_time}`}
+                    aria-label={`Block timestamp: ${formatTimestampToRelativeTime(burnBlock.burn_block_time)}`}
                     suppressHydrationWarning
                   >
-                    {formatTimestampTo12HourTime(burnBlock.burn_block_time, {
-                      useLocalTime: true,
-                      includeSeconds: true,
-                    })}
+                    {formatTimestampToRelativeTime(burnBlock.burn_block_time)}
                   </Text>
                 </Stack>
                 <HStack gap={1.5} p={2} borderRadius={'redesign.md'} bg={'surfacePrimary'}>

--- a/src/app/_components/RecentBlocks/StxBlock.tsx
+++ b/src/app/_components/RecentBlocks/StxBlock.tsx
@@ -1,5 +1,8 @@
 import { UIStxBlock } from '@/app/data';
-import { formatTimestampTo12HourTime } from '@/common/utils/time-utils';
+import {
+  formatTimestampTo12HourTime,
+  formatTimestampToRelativeTime,
+} from '@/common/utils/time-utils';
 import { Flex, HStack, Icon, Stack } from '@chakra-ui/react';
 import { CaretRight, Circle } from '@phosphor-icons/react';
 
@@ -88,10 +91,7 @@ export function StxBlockGroup({
                 lineHeight={'redesign.shorter'}
                 suppressHydrationWarning
               >
-                {formatTimestampTo12HourTime(btcBlockTime, {
-                  useLocalTime: true,
-                  includeSeconds: true,
-                })}
+                {formatTimestampToRelativeTime(btcBlockTime)}
               </Text>
               <Text
                 textStyle={'text-medium-xs'}
@@ -202,10 +202,7 @@ export function StxBlock({ stxBlock }: { stxBlock: UIStxBlock }) {
                 aria-label={`Block timestamp: ${stxBlock.burn_block_time}`}
                 suppressHydrationWarning
               >
-                {formatTimestampTo12HourTime(stxBlock.burn_block_time, {
-                  useLocalTime: true,
-                  includeSeconds: true,
-                })}
+                {formatTimestampToRelativeTime(stxBlock.burn_block_time)}
               </Text>
               <Text
                 textStyle={'text-medium-xs'}
@@ -300,10 +297,7 @@ export function NewestStxBlock({ stxBlock }: { stxBlock: UIStxBlock }) {
                 align={'center'}
               >
                 <Text textStyle={'text-medium-xs'} color={'textSecondary'} suppressHydrationWarning>
-                  {formatTimestampTo12HourTime(stxBlock.block_time, {
-                    useLocalTime: true,
-                    includeSeconds: true,
-                  })}
+                  {formatTimestampToRelativeTime(stxBlock.block_time)}
                 </Text>
                 <Text textStyle={'text-medium-xs'} color={'textSecondary'}>
                   {stxBlock.tx_count} tx{stxBlock.tx_count > 1 ? 's' : ''}


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [ ] Refactor
- [ ] Feature
- [X] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
Switches the timestamps on the recent blocks section from 12 hour format to relative time

## Issue ticket number and link
closes https://github.com/hirosystems/explorer/issues/2200

# Checklist:
- [X] I have performed a self-review of my code.
- [X] I have tested the change on desktop and mobile.
- [ ] I have added thorough tests where applicable.
- [ ] I've added analytics and error logging where applicable.

## Screenshots (if appropriate):
<!--- Add screenshots of your changes -->