### PR TITLE
chore: removed recent blocks underline and show it only on hover

### DIFF
--- a/src/app/_components/RecentBlocks/BtcBlock.tsx
+++ b/src/app/_components/RecentBlocks/BtcBlock.tsx
@@ -39,6 +39,7 @@ export function BtcBlock({ burnBlock }: { burnBlock: BurnBlock }) {
         )} with ${burnBlock.stacks_blocks.length} Stacks blocks`}
         role="listitem"
         tabIndex={0}
+        variant="underlineOnHover"
       >
         <Stack
           position="relative"

--- a/src/ui/theme/recipes/LinkRecipe.ts
+++ b/src/ui/theme/recipes/LinkRecipe.ts
@@ -32,6 +32,12 @@ export const linkRecipe = defineRecipe({
           textDecoration: 'underline',
         },
       },
+      underlineOnHover: {
+        textDecoration: 'none',
+        _hover: {
+          textDecoration: 'underline',
+        },
+      },
       tableLink: {
         textDecoration: 'underline',
         _hover: {


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [ ] Refactor
- [X] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
Removed recent blocks default underline and only show it on hover

## Issue ticket number and link
closes https://github.com/hirosystems/explorer/issues/2202

# Checklist:
- [X] I have performed a self-review of my code.
- [X] I have tested the change on desktop and mobile.
- [ ] I have added thorough tests where applicable.
- [ ] I've added analytics and error logging where applicable.

## Screenshots (if appropriate):
<!--- Add screenshots of your changes -->
