### PR TITLE
fix: fixed tx page table timestamps

### DIFF
--- a/src/app/_components/TxsSection.tsx
+++ b/src/app/_components/TxsSection.tsx
@@ -73,7 +73,7 @@ export const columnDefinitions: ColumnDef<TxTableData>[] = [
       <Flex alignItems="center" justifyContent="flex-end" w="full">
         {TimeStampCellRenderer(
           formatTimestampToRelativeTime(info.getValue() as number),
-          formatTimestamp(info.getValue() as number, 'HH:mm:ss')
+          formatTimestamp(info.getValue() as number, 'HH:mm:ss', true)
         )}
       </Flex>
     ),

--- a/src/common/components/table/table-examples/TxsTable.tsx
+++ b/src/common/components/table/table-examples/TxsTable.tsx
@@ -6,7 +6,7 @@ import { CompressedTxTableData } from '@/app/transactions/utils';
 import { GenericResponseType } from '@/common/hooks/useInfiniteQueryResult';
 import { THIRTY_SECONDS } from '@/common/queries/query-stale-time';
 import { useConfirmedTransactions } from '@/common/queries/useConfirmedTransactionsInfinite';
-import { formatTimestamp } from '@/common/utils/time-utils';
+import { formatTimestamp, formatTimestampToRelativeTime } from '@/common/utils/time-utils';
 import { microToStacksFormatted, validateStacksContractId } from '@/common/utils/utils';
 import { Text } from '@/ui/Text';
 import { Box, Table as ChakraTable, Flex, Icon } from '@chakra-ui/react';
@@ -163,7 +163,10 @@ export const defaultColumnDefinitions: ColumnDef<TxTableData>[] = [
     accessorKey: TxTableColumns.BlockTime,
     cell: info => (
       <Flex alignItems="center" justifyContent="flex-end" w="full">
-        {TimeStampCellRenderer(formatTimestamp(info.getValue() as number))}
+        {TimeStampCellRenderer(
+          formatTimestampToRelativeTime(info.getValue() as number),
+          formatTimestamp(info.getValue() as number, 'HH:mm:ss', true)
+        )}
       </Flex>
     ),
     enableSorting: false,

--- a/src/common/utils/time-utils.ts
+++ b/src/common/utils/time-utils.ts
@@ -57,11 +57,19 @@ export function formatTimestampTo12HourTime(
 
 export function formatTimestamp(
   timestampInSeconds: number,
-  formatString: string = 'yyyy-MM-dd HH:mm:ss'
+  formatString: string = 'yyyy-MM-dd HH:mm:ss',
+  includeTimezone: boolean = false
 ): string {
   const date = new Date(timestampInSeconds * 1000);
+
+  const formatter = new Intl.DateTimeFormat('en-US', {
+    timeZoneName: 'short',
+  });
+  const parts = formatter.formatToParts(date);
+  const tzPart = parts.find(part => part.type === 'timeZoneName');
+
   const formatted = format(date, formatString);
-  return formatted;
+  return includeTimezone ? `${formatted} ${tzPart?.value}` : formatted;
 }
 
 export function formatTimestampToRelativeTime(timestampInSeconds: number): string {


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [ ] Refactor
- [ ] Feature
- [X] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
Fixes the tx page timestamps showing in utc due to being server rendered by switching them to relative time

## Issue ticket number and link

# Checklist:
- [X] I have performed a self-review of my code.
- [X] I have tested the change on desktop and mobile.
- [ ] I have added thorough tests where applicable.
- [ ] I've added analytics and error logging where applicable.

## Screenshots (if appropriate):
<!--- Add screenshots of your changes -->
