### PR TITLE
feat: default to deploy using Clarity 3

### DIFF
--- a/src/app/sandbox/deploy/LeftSection.tsx
+++ b/src/app/sandbox/deploy/LeftSection.tsx
@@ -96,7 +96,7 @@ export function LeftSection() {
         </Stack>
         <Stack gap={2}>
           <Text fontSize="xs" as="p">
-            The sandbox doesn't support Clarity 3 deployments. To deploy a Clarity 3 contract,
+            The sandbox only supports Clarity 3 deployments. To deploy using a different version,
             please use{' '}
             <TextLink
               display="inline"

--- a/src/app/sandbox/utils/walletTransactions.ts
+++ b/src/app/sandbox/utils/walletTransactions.ts
@@ -60,7 +60,7 @@ export const deployContract = async (params: {
     const response = await request('stx_deployContract', {
       name: params.name,
       clarityCode: params.clarityCode,
-      clarityVersion: params.clarityVersion || 2,
+      clarityVersion: params.clarityVersion || 3,
       network: params.network || 'mainnet',
       postConditionMode: 'allow',
     });


### PR DESCRIPTION
I'm hoping this is all that is needed to make the sandbox use Clarity 3 for contract deployments. This would solve confusion from users, since most are expecting to deploy using the latest version of Clarity.