### PR TITLE
feat: reduced the cache time to 3 sec and removed revalidation

### DIFF
--- a/src/app/txid/[txId]/PageClient.tsx
+++ b/src/app/txid/[txId]/PageClient.tsx
@@ -1,12 +1,9 @@
 'use client';
 
-import { logError } from '@/common/utils/error-utils';
 import { useIsRedesignUrl } from '@/common/utils/url-utils';
 import dynamic from 'next/dynamic';
-import { useEffect } from 'react';
 
 import { useTxIdPageData } from './TxIdPageContext';
-import { getTxTag } from './page-data';
 import { CoinbasePage as CoinbasePageRedesign } from './redesign/CoinbasePage';
 import { ContractCallPage as ContractCallPageRedesign } from './redesign/ContractCallPage';
 import { TenureChangePage as TenureChangePageRedesign } from './redesign/TenureChangePage';
@@ -36,26 +33,6 @@ const PoisonMicroblock = dynamic(() => import('./PoisonMicroblock'), {
 function TransactionIdPage() {
   const { initialTxData: tx, txId } = useTxIdPageData();
   const isRedesign = useIsRedesignUrl();
-
-  // Revalidate tx-id page if tx is pending
-  useEffect(() => {
-    const revalidateTxIdPage = async () => {
-      const txStatus = tx?.tx_status;
-      if (txStatus === 'pending') {
-        try {
-          const revalidateUrl = `/api/revalidate?tag=${getTxTag(txId)}`;
-          const revalidateResponse = await fetch(revalidateUrl);
-          if (!revalidateResponse.ok) {
-            throw new Error('Failed to revalidate tx id page for txId: ' + txId);
-          }
-        } catch (error) {
-          logError(error as Error, 'Revalidating tx-id page for txId: ' + txId, { txId, txStatus });
-        }
-      }
-    };
-
-    revalidateTxIdPage();
-  }, []);
 
   const isContractId = txId.includes('.');
   if (isContractId) {

--- a/src/app/txid/[txId]/page-data.ts
+++ b/src/app/txid/[txId]/page-data.ts
@@ -3,8 +3,7 @@ import { stacksAPIFetch } from '@/api/stacksAPIFetch';
 import { MempoolTransaction, Transaction } from '@stacks/stacks-blockchain-api-types';
 
 export const getTxTag = (txId: string) => `tx-id-${txId}`;
-const PENDING_TX_REVALIDATION_INTERVAL_IN_MS = 7 * 1000; // 7 seconds
-const CONFIRMED_TX_REVALIDATION_TIMEOUT_IN_SECONDS = 600; // 10 minutes
+const CONFIRMED_TX_REVALIDATION_TIMEOUT_IN_SECONDS = 3; // 3 seconds
 
 export async function fetchTxById(
   apiUrl: string,


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [ ] Refactor
- [X] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
Slack context here: https://hiropbc.slack.com/archives/C03TU42NL05/p1756141645153409
Reducing the cache time on tx id pages to reduce inconsistencies in tx status perhaps due to the complexity of maintaining a 10 min cache time for confirmed txs and relying on client revalidation for pending txs
Link to smoke test: https://grafana.stg.hiro.tools/d/k6_prometheus/k6-prometheus?orgId=1&from=now-3h&to=now&timezone=browser&var-DS_PROMETHEUS=mimir&var-testid=$__all&var-quantile_stat=p99&var-adhoc_filter=

## Issue ticket number and link

# Checklist:
- [X] I have performed a self-review of my code.
- [X] I have tested the change on desktop and mobile.
- [ ] I have added thorough tests where applicable.
- [ ] I've added analytics and error logging where applicable.

## Screenshots (if appropriate):
<!--- Add screenshots of your changes -->
