### PR TITLE
fix: home page blocks widget

### DIFF
--- a/src/app/_components/RecentBlocks/NewBlockPlaceholder.tsx
+++ b/src/app/_components/RecentBlocks/NewBlockPlaceholder.tsx
@@ -2,52 +2,22 @@
 
 import { Box, Icon, Stack, StackProps } from '@chakra-ui/react';
 import { ArrowsClockwise } from '@phosphor-icons/react';
-import { useCallback, useEffect, useRef, useState } from 'react';
-
-import { Block, NakamotoBlock } from '@stacks/blockchain-api-client';
 
 import { Text } from '../../../ui/Text';
-import { useSubscribeBlocks } from '../BlockList/Sockets/useSubscribeBlocks';
 import { BTC_BLOCK_MIN_WIDTH, EMPTY_BTC_BLOCK_WIDTH } from './consts';
 
+interface NewBlockPlaceholderProps extends Omit<StackProps, 'boxShadow'> {
+  hasNewBlocks: boolean;
+  handleUpdate: () => void;
+  boxShadow?: string;
+}
+
 export function NewBlockPlaceholder({
-  newestBlockHeight,
-  refetch,
+  hasNewBlocks,
+  handleUpdate,
   boxShadow,
-  isNewBlock,
   ...stackProps
-}: {
-  newestBlockHeight: number;
-  refetch: () => void;
-  isNewBlock: (block: NakamotoBlock | Block, lastBlockHeight: number) => boolean;
-} & StackProps) {
-  const [hasNewBlocks, setHasNewBlocks] = useState(false);
-  const [socketEnabled, setSocketEnabled] = useState(true);
-  const lastBlockHeightRef = useRef(newestBlockHeight);
-
-  const handleNewBlock = useCallback(
-    (block: NakamotoBlock | Block) => {
-      if (isNewBlock(block, lastBlockHeightRef.current)) {
-        setHasNewBlocks(true);
-        setSocketEnabled(false);
-      }
-    },
-    [isNewBlock]
-  );
-
-  useSubscribeBlocks(socketEnabled, handleNewBlock);
-
-  useEffect(() => {
-    lastBlockHeightRef.current = newestBlockHeight;
-    setHasNewBlocks(false);
-  }, [newestBlockHeight]);
-
-  const handleUpdate = useCallback(() => {
-    refetch();
-    setHasNewBlocks(false);
-    setSocketEnabled(true);
-  }, [refetch]);
-
+}: NewBlockPlaceholderProps) {
   return (
     <Stack
       width={hasNewBlocks ? BTC_BLOCK_MIN_WIDTH : EMPTY_BTC_BLOCK_WIDTH}
@@ -98,5 +68,27 @@ export function NewBlockPlaceholder({
         </Text>
       </Box>
     </Stack>
+  );
+}
+
+export function StacksNewBlockPlaceholder({ ...props }: NewBlockPlaceholderProps) {
+  return (
+    <NewBlockPlaceholder
+      id="stacks-new-block-placeholder"
+      border="1px dashed var(--stacks-colors-accent-stacks-500)"
+      boxShadow={'0px 4px 12px 0px rgba(255, 85, 18, 0.25)'}
+      {...props}
+    />
+  );
+}
+
+export function BtcNewBlockPlaceholder({ ...props }: NewBlockPlaceholderProps) {
+  return (
+    <NewBlockPlaceholder
+      id="btc-new-block-placeholder"
+      border="1px dashed var(--stacks-colors-accent-bitcoin-500)"
+      boxShadow={'0px 4px 12px 0px rgba(255, 145, 0, 0.25)'}
+      {...props}
+    />
   );
 }

--- a/src/app/_components/RecentBlocks/RecentBlocks.tsx
+++ b/src/app/_components/RecentBlocks/RecentBlocks.tsx
@@ -1,8 +1,13 @@
 'use client';
 
+import { useHomePageData } from '@/app/context';
 import { ButtonLink } from '@/ui/ButtonLink';
 import { Text } from '@/ui/Text';
 import { HStack, Icon, Stack } from '@chakra-ui/react';
+import { useState } from 'react';
+
+import { BurnBlock } from '@stacks/blockchain-api-client';
+import { NakamotoBlock } from '@stacks/stacks-blockchain-api-types';
 
 import { useGlobalContext } from '../../../common/context/useGlobalContext';
 import { buildUrl } from '../../../common/utils/buildUrl';
@@ -11,6 +16,7 @@ import BitcoinIcon from '../../../ui/icons/BitcoinIcon';
 import StacksIconThin from '../../../ui/icons/StacksIconThin';
 import { RecentBtcBlocks } from './RecentBtcBlocks';
 import { RecentStxBlocks } from './RecentStxBlocks';
+import { RecentBlocksType, useRecentBlocks } from './useRecentBlocks';
 
 function SectionHeader() {
   const network = useGlobalContext().activeNetwork;
@@ -32,6 +38,25 @@ function SectionHeader() {
 }
 
 export function RecentBlocks() {
+  const { initialRecentBlocks } = useHomePageData();
+
+  const initialStxBlocksData = initialRecentBlocks?.stxBlocks.results as NakamotoBlock[];
+  const initialBtcBlocksData = initialRecentBlocks?.btcBlocks.results as BurnBlock[];
+
+  const [activeTab, setActiveTab] = useState<RecentBlocksType>('btc');
+  const {
+    stxBlocks: newStxBlocksData,
+    btcBlocks: newBtcBlocksData,
+    hasNewBtcBlocks,
+    hasNewStxBlocks,
+    handleUpdate,
+  } = useRecentBlocks(activeTab);
+
+  const stxBlocks =
+    newStxBlocksData && newStxBlocksData.length > 0 ? newStxBlocksData : initialStxBlocksData || [];
+  const btcBlocks =
+    newBtcBlocksData && newBtcBlocksData.length > 0 ? newBtcBlocksData : initialBtcBlocksData || [];
+
   return (
     <Stack aria-label="Recent blocks" gap={4}>
       <TabsRoot
@@ -41,6 +66,8 @@ export function RecentBlocks() {
         gap={2}
         lazyMount
         aria-label="Block view options"
+        onValueChange={details => setActiveTab(details.value as RecentBlocksType)}
+        value={activeTab}
       >
         <HStack gap={0} pb={4} w={'100%'}>
           <TabsLabel as="span" id="tab-group-label" whiteSpace={'nowrap'}>
@@ -63,11 +90,20 @@ export function RecentBlocks() {
         </HStack>
 
         <TabsContent value="btc" aria-label="Bitcoin blocks tab panel" role="tabpanel" tabIndex={0}>
-          <RecentBtcBlocks />
+          <RecentBtcBlocks
+            hasNewBlocks={hasNewBtcBlocks}
+            handleUpdate={handleUpdate}
+            btcBlocks={btcBlocks}
+          />
         </TabsContent>
 
         <TabsContent value="stx" aria-label="Stacks blocks tab panel" role="tabpanel" tabIndex={0}>
-          <RecentStxBlocks />
+          <RecentStxBlocks
+            hasNewBlocks={hasNewStxBlocks}
+            handleUpdate={handleUpdate}
+            stxBlocks={stxBlocks}
+            btcBlocks={btcBlocks}
+          />
         </TabsContent>
       </TabsRoot>
     </Stack>

--- a/src/app/_components/RecentBlocks/RecentBtcBlocks.tsx
+++ b/src/app/_components/RecentBlocks/RecentBtcBlocks.tsx
@@ -1,49 +1,35 @@
-import { useHomePageData } from '@/app/context';
-import { BURN_BLOCKS_QUERY_KEY } from '@/common/queries/useBurnBlock';
 import { HStack } from '@chakra-ui/react';
-import { useQueryClient } from '@tanstack/react-query';
-import { useRef } from 'react';
 
-import { useBurnBlocks } from '../../../common/queries/useBurnBlocksInfinite';
+import { BurnBlock } from '@stacks/blockchain-api-client';
+import { Block, NakamotoBlock } from '@stacks/stacks-blockchain-api-types';
+
 import { BtcBlock, NewestBtcBlock } from './BtcBlock';
 import { FadingOverlay } from './FadingOverlay';
-import { NewBlockPlaceholder } from './NewBlockPlaceholder';
-import { BLOCK_HEIGHT, RECENT_BTC_BLOCKS_COUNT } from './consts';
+import { BtcNewBlockPlaceholder } from './NewBlockPlaceholder';
+import { BLOCK_HEIGHT } from './consts';
 
-export function RecentBtcBlocks() {
-  const recentBtcBlocks = useHomePageData().initialRecentBlocks?.btcBlocks;
-  const queryClient = useQueryClient();
-  const isCacheSetWithInitialData = useRef(false);
+function isNewBlock(block: NakamotoBlock | Block, lastBlockHeight: number | undefined) {
+  return block.burn_block_height > (lastBlockHeight || 0);
+}
 
-  if (isCacheSetWithInitialData.current === false && recentBtcBlocks) {
-    const queryKey = [BURN_BLOCKS_QUERY_KEY, RECENT_BTC_BLOCKS_COUNT];
-    queryClient.setQueryData(queryKey, recentBtcBlocks);
-    isCacheSetWithInitialData.current = true;
-  }
-
-  const { data: btcBlocksData, refetch } = useBurnBlocks(RECENT_BTC_BLOCKS_COUNT, undefined, {
-    manual: true,
-  });
-
-  const btcBlocks = btcBlocksData?.results || [];
-  const newestBtcBlock = btcBlocks[0];
-  if (!newestBtcBlock) {
+export function RecentBtcBlocks({
+  btcBlocks,
+  hasNewBlocks,
+  handleUpdate,
+}: {
+  btcBlocks: BurnBlock[];
+  hasNewBlocks: boolean;
+  handleUpdate: () => void;
+}) {
+  if (!btcBlocks || btcBlocks.length <= 0) {
     return null;
   }
 
   return (
     <HStack h={BLOCK_HEIGHT} gap={3} align={'normal'} position={'relative'}>
-      <NewBlockPlaceholder
-        newestBlockHeight={newestBtcBlock?.burn_block_height || Infinity}
-        isNewBlock={(block, lastBlockHeight) => {
-          return block.burn_block_height > lastBlockHeight;
-        }}
-        refetch={refetch}
-        border="1px dashed var(--stacks-colors-accent-bitcoin-500)"
-        boxShadow={'0px 4px 12px 0px rgba(255, 145, 0, 0.25)'}
-      />
+      <BtcNewBlockPlaceholder hasNewBlocks={hasNewBlocks} handleUpdate={handleUpdate} />
       <HStack gap={1} align="stretch" minW={0} flex={1}>
-        <NewestBtcBlock burnBlock={newestBtcBlock} />
+        <NewestBtcBlock burnBlock={btcBlocks[0]} />
         <HStack gap={3} align="stretch" overflowX={'hidden'} minW={0}>
           {btcBlocks.slice(1).map(block => (
             <BtcBlock key={block.burn_block_hash} burnBlock={block} />

--- a/src/app/_components/RecentBlocks/RecentStxBlocks.tsx
+++ b/src/app/_components/RecentBlocks/RecentStxBlocks.tsx
@@ -1,37 +1,26 @@
-import { BLOCKS_V2_QUERY_KEY, useBlocksV2List } from '@/app/blocks/queries/useBlocksV2Queries';
-import { useHomePageData } from '@/app/context';
 import { UIStxBlock } from '@/app/data';
-import { useGlobalContext } from '@/common/context/useGlobalContext';
 import { HStack } from '@chakra-ui/react';
-import { useQueryClient } from '@tanstack/react-query';
-import { useMemo, useRef } from 'react';
+import { useMemo } from 'react';
 
-import { NakamotoBlock } from '@stacks/stacks-blockchain-api-types';
+import { BurnBlock, NakamotoBlock } from '@stacks/stacks-blockchain-api-types';
 
 import { FadingOverlay } from './FadingOverlay';
-import { NewBlockPlaceholder } from './NewBlockPlaceholder';
+import { StacksNewBlockPlaceholder } from './NewBlockPlaceholder';
 import { StxBlockGroup } from './StxBlock';
-import { BLOCK_HEIGHT, RECENT_STX_BLOCKS_COUNT } from './consts';
+import { BLOCK_HEIGHT } from './consts';
 
-export function RecentStxBlocks() {
-  const { initialRecentBlocks } = useHomePageData();
-  const { activeNetwork } = useGlobalContext();
-  const recentStxBlocks = initialRecentBlocks?.stxBlocks;
-  const recentBtcBlocks = initialRecentBlocks?.btcBlocks;
-  const queryClient = useQueryClient();
-  const isCacheSetWithInitialData = useRef(false);
-
-  if (isCacheSetWithInitialData.current === false && recentStxBlocks) {
-    const queryKey = [BLOCKS_V2_QUERY_KEY, RECENT_STX_BLOCKS_COUNT, activeNetwork.url];
-    queryClient.setQueryData(queryKey, recentStxBlocks);
-    isCacheSetWithInitialData.current = true;
-  }
-
-  const { data: stxBlocksData, refetch } = useBlocksV2List(RECENT_STX_BLOCKS_COUNT, {
-    enabled: false,
-  });
-  const stxBlocks = stxBlocksData?.results || [];
-
+export function RecentStxBlocks({
+  stxBlocks,
+  btcBlocks,
+  hasNewBlocks,
+  handleUpdate,
+}: {
+  stxBlocks: NakamotoBlock[];
+  btcBlocks: BurnBlock[];
+  hasNewBlocks: boolean;
+  handleUpdate: () => void;
+}) {
+  // Group blocks by burn block height, and sort the groups by burn block height
   const stxBlocksByBurnBlockHeight = useMemo(() => {
     const groupedByBurnBlockHeight = stxBlocks.reduce(
       (acc, block) => {
@@ -51,16 +40,18 @@ export function RecentStxBlocks() {
     return groupedByBurnBlockHeight;
   }, [stxBlocks]);
 
+  // Get the burn block heights in descending order
   const sortedBurnBlockHeights = useMemo(() => {
     return Object.keys(stxBlocksByBurnBlockHeight)
       .map(height => Number(height))
       .sort((a, b) => b - a);
   }, [stxBlocksByBurnBlockHeight]);
 
+  // Get the total number of Stacks blocks for each burn block height
   const totalStxBlockCountByBurnBlockHeight = useMemo(() => {
     return Object.keys(stxBlocksByBurnBlockHeight).reduce(
       (acc, burnBlockHeight) => {
-        const stxBlocksCount = recentBtcBlocks?.results?.find(
+        const stxBlocksCount = btcBlocks?.find(
           block => block.burn_block_height === Number(burnBlockHeight)
         )?.stacks_blocks?.length;
         acc[Number(burnBlockHeight)] = stxBlocksCount || 0;
@@ -68,25 +59,18 @@ export function RecentStxBlocks() {
       },
       {} as Record<number, number>
     );
-  }, [recentBtcBlocks]);
+  }, [btcBlocks, stxBlocksByBurnBlockHeight]);
 
-  const newestStxBlockHeight = stxBlocks[0]?.height;
+  // Get the height of the newest Stacks block
+  const newestStxBlockHeight = useMemo(() => stxBlocks[0]?.height, [stxBlocks]);
 
-  if (!newestStxBlockHeight) {
+  if (!stxBlocks || stxBlocks.length <= 0 || !btcBlocks || btcBlocks.length <= 0) {
     return null;
   }
 
   return (
     <HStack gap={3} h={BLOCK_HEIGHT} position={'relative'} align={'normal'} flexGrow={1}>
-      <NewBlockPlaceholder
-        newestBlockHeight={newestStxBlockHeight || Infinity}
-        isNewBlock={(block, lastBlockHeight) => {
-          return block.height > lastBlockHeight;
-        }}
-        refetch={refetch}
-        border="1px dashed var(--stacks-colors-accent-stacks-500)"
-        boxShadow={'0px 4px 12px 0px rgba(255, 85, 18, 0.25)'}
-      />
+      <StacksNewBlockPlaceholder hasNewBlocks={hasNewBlocks} handleUpdate={handleUpdate} />
       <HStack gap={3} overflowX={'hidden'} align="stretch">
         {sortedBurnBlockHeights.map(burnBlockHeight => (
           <StxBlockGroup

--- a/src/app/_components/RecentBlocks/StxBlock.tsx
+++ b/src/app/_components/RecentBlocks/StxBlock.tsx
@@ -1,7 +1,6 @@
 import { UIStxBlock } from '@/app/data';
 import { formatTimestampToRelativeTime } from '@/common/utils/time-utils';
 import { BlockHeightBadge } from '@/ui/Badge';
-import StacksIconBlock from '@/ui/icons/StacksIconBlock';
 import { Flex, HStack, Icon, Stack } from '@chakra-ui/react';
 import { CaretRight, Circle } from '@phosphor-icons/react';
 

--- a/src/app/_components/RecentBlocks/useRecentBlocks.ts
+++ b/src/app/_components/RecentBlocks/useRecentBlocks.ts
@@ -1,0 +1,150 @@
+'use client';
+
+import { getBlocksV2ListQueryKey, useBlocksV2List } from '@/app/blocks/queries/useBlocksV2Queries';
+import { useHomePageData } from '@/app/context';
+import { getBurnBlocksQueryKey, useBurnBlocks } from '@/common/queries/useBurnBlocksInfinite';
+import { useQueryClient } from '@tanstack/react-query';
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+import { Block, NakamotoBlock } from '@stacks/stacks-blockchain-api-types';
+
+import { useGlobalContext } from '../../../common/context/useGlobalContext';
+import { useSubscribeBlocks } from '../BlockList/Sockets/useSubscribeBlocks';
+import { RECENT_BTC_BLOCKS_COUNT, RECENT_STX_BLOCKS_COUNT } from './consts';
+
+export type RecentBlocksType = 'btc' | 'stx';
+
+const isNewStxBlock = (block: NakamotoBlock | Block, lastBlockHeight: number | undefined) => {
+  return block.height > (lastBlockHeight || 0);
+};
+
+const isNewBtcBlock = (block: NakamotoBlock | Block, lastBlockHeight: number | undefined) => {
+  return block.burn_block_height > (lastBlockHeight || 0);
+};
+
+// Handle getting stx blocks data. If there is initial stx blocks data, set it in the cache and use it. Otherwise, query for the data
+const useStxBlocks = () => {
+  const { initialRecentBlocks } = useHomePageData();
+  const activeNetwork = useGlobalContext().activeNetwork;
+
+  const queryClient = useQueryClient();
+
+  const recentStxBlocks = initialRecentBlocks?.stxBlocks;
+  const isStxBlocksCacheSetWithInitialData = useRef(false);
+
+  useEffect(() => {
+    if (isStxBlocksCacheSetWithInitialData.current === false && recentStxBlocks) {
+      const queryKey = getBlocksV2ListQueryKey(RECENT_STX_BLOCKS_COUNT, activeNetwork.url);
+      queryClient.setQueryData(queryKey, recentStxBlocks);
+      isStxBlocksCacheSetWithInitialData.current = true;
+    }
+  }, [recentStxBlocks, activeNetwork.url, queryClient]);
+
+  const { data: stxBlocksData, refetch: stxRefetch } = useBlocksV2List(RECENT_STX_BLOCKS_COUNT, {
+    enabled: false,
+  });
+  const stxBlocks = stxBlocksData?.results || [];
+  return { stxBlocks, stxRefetch };
+};
+
+// Handle getting btc blocks data. If there is initial btc blocks data, set it in the cache and use it. Otherwise, query for the data
+const useBtcBlocks = () => {
+  const { initialRecentBlocks } = useHomePageData();
+  const activeNetwork = useGlobalContext().activeNetwork;
+
+  const queryClient = useQueryClient();
+
+  const recentBtcBlocks = initialRecentBlocks?.btcBlocks;
+  const isBtcBlocksCacheSetWithInitialData = useRef(false);
+
+  useEffect(() => {
+    if (isBtcBlocksCacheSetWithInitialData.current === false && recentBtcBlocks) {
+      const queryKey = getBurnBlocksQueryKey({
+        limit: RECENT_BTC_BLOCKS_COUNT,
+        networkUrl: activeNetwork.url,
+        queryKeyExtension: 'recent',
+      });
+      queryClient.setQueryData(queryKey, recentBtcBlocks);
+      isBtcBlocksCacheSetWithInitialData.current = true;
+    }
+  }, [recentBtcBlocks, activeNetwork.url, queryClient]);
+
+  const { data: btcBlocksData, refetch: btcRefetch } = useBurnBlocks(
+    RECENT_BTC_BLOCKS_COUNT,
+    undefined,
+    {
+      enabled: false,
+    }
+  );
+  const btcBlocks = btcBlocksData?.results || [];
+  return { btcBlocks, btcRefetch };
+};
+
+export function useRecentBlocks(recentBlocksType: RecentBlocksType) {
+  const [hasNewBtcBlocks, setHasNewBtcBlocks] = useState(false);
+  const [hasNewStxBlocks, setHasNewStxBlocks] = useState(false);
+  const [socketEnabled, setSocketEnabled] = useState(true);
+
+  const { stxBlocks, stxRefetch } = useStxBlocks();
+  const newestStxBlockHeight = stxBlocks[0]?.height;
+
+  const { btcBlocks, btcRefetch } = useBtcBlocks();
+  const newestBtcBlockHeight = btcBlocks[0]?.burn_block_height;
+
+  useEffect(() => {}, [recentBlocksType, socketEnabled, hasNewBtcBlocks, hasNewStxBlocks]);
+
+  // Update socketEnabled state when we have new blocks for the selected type or when we switch tabs
+  useEffect(() => {
+    // When we get new blocks for the selected type, we turn the socket off
+    if (recentBlocksType === 'btc' && hasNewBtcBlocks && socketEnabled) {
+      setSocketEnabled(false);
+    }
+    if (recentBlocksType === 'stx' && hasNewStxBlocks && socketEnabled) {
+      setSocketEnabled(false);
+    }
+
+    // However, we need to consider turning the socket back on when we switch tabs, if, for the selected type, we don't have new blocks
+    if (recentBlocksType === 'btc' && !hasNewBtcBlocks && !socketEnabled) {
+      setSocketEnabled(true);
+    }
+    if (recentBlocksType === 'stx' && !hasNewStxBlocks && !socketEnabled) {
+      setSocketEnabled(true);
+    }
+  }, [hasNewBtcBlocks, hasNewStxBlocks, recentBlocksType, socketEnabled]);
+
+  // When a new block is received, update the hasNewBlocks state for the selected type
+  const handleNewBlock = useCallback(
+    (block: NakamotoBlock | Block) => {
+      if (isNewBtcBlock(block, newestBtcBlockHeight)) {
+        setHasNewBtcBlocks(true);
+      }
+      if (isNewStxBlock(block, newestStxBlockHeight)) {
+        setHasNewStxBlocks(true);
+      }
+    },
+    [newestBtcBlockHeight, newestStxBlockHeight]
+  );
+
+  // When we click the update button, refetch the data and reset the hasNewBlocks state for the selected type and enable the socket as we need to listen for new blocks
+  const handleUpdate = useCallback(() => {
+    if (recentBlocksType === 'btc') {
+      btcRefetch();
+      setHasNewBtcBlocks(false);
+    } else {
+      stxRefetch();
+      setHasNewStxBlocks(false);
+    }
+    setSocketEnabled(true);
+  }, [recentBlocksType, btcRefetch, stxRefetch]);
+
+  // Subscribe to new blocks
+  useSubscribeBlocks(socketEnabled, handleNewBlock);
+
+  return {
+    stxBlocks,
+    btcBlocks,
+    hasNewBtcBlocks,
+    hasNewStxBlocks,
+    handleUpdate,
+  };
+}

--- a/src/app/blocks/queries/useBlocksV2Queries.ts
+++ b/src/app/blocks/queries/useBlocksV2Queries.ts
@@ -1,10 +1,4 @@
-import {
-  UseInfiniteQueryOptions,
-  UseQueryResult,
-  useInfiniteQuery,
-  useQuery,
-  useSuspenseInfiniteQuery,
-} from '@tanstack/react-query';
+import { UseQueryResult, useInfiniteQuery, useQuery } from '@tanstack/react-query';
 
 import { NakamotoBlock } from '@stacks/stacks-blockchain-api-types';
 
@@ -15,7 +9,16 @@ import { GenericResponseType } from '../../../common/hooks/useInfiniteQueryResul
 import { TWO_MINUTES } from '../../../common/queries/query-stale-time';
 import { getNextPageParam } from '../../../common/utils/utils';
 
-export const BLOCKS_V2_QUERY_KEY = 'blocksV2Infinite';
+export const BLOCKS_V2_INFINITE_QUERY_KEY = 'blocksV2Infinite';
+export const BLOCKS_V2_LIST_QUERY_KEY = 'blocksV2List';
+
+export function getBlocksV2InfiniteQueryKey(limit: number, network: string) {
+  return [BLOCKS_V2_INFINITE_QUERY_KEY, limit, network];
+}
+
+export function getBlocksV2ListQueryKey(limit: number, network: string) {
+  return [BLOCKS_V2_LIST_QUERY_KEY, limit, network];
+}
 
 export const useBlocksV2Infinite = (
   limit = DEFAULT_LIST_LIMIT,
@@ -30,7 +33,7 @@ export const useBlocksV2Infinite = (
 ) => {
   const { apiClient, activeNetwork } = useGlobalContext();
   return useInfiniteQuery({
-    queryKey: [BLOCKS_V2_QUERY_KEY, limit, activeNetwork.url],
+    queryKey: getBlocksV2InfiniteQueryKey(limit, activeNetwork.url),
     queryFn: async ({ pageParam }) => {
       const offset = pageParam || 0;
       const url = `${activeNetwork.url}/extended/v2/blocks/?limit=${limit}&offset=${offset}`;
@@ -56,7 +59,7 @@ export const useBlocksV2List = (
   const { apiClient, activeNetwork } = useGlobalContext();
 
   return useQuery({
-    queryKey: [BLOCKS_V2_QUERY_KEY, limit, activeNetwork.url],
+    queryKey: getBlocksV2ListQueryKey(limit, activeNetwork.url),
     queryFn: async () => {
       const url = `${activeNetwork.url}/extended/v2/blocks/?limit=${limit}`;
       const response = await stacksAPIFetch(url);

--- a/src/app/context.tsx
+++ b/src/app/context.tsx
@@ -1,9 +1,6 @@
 'use client';
 
-import { FeeCalculationTypes, Fees } from '@leather.io/models';
 import { ReactNode, createContext, useContext } from 'react';
-
-import { MempoolFeePriorities } from '@stacks/stacks-blockchain-api-types';
 
 import { RecentBlocks, UIMempoolStats, UIStackingCycle } from './data';
 

--- a/src/app/data.ts
+++ b/src/app/data.ts
@@ -65,7 +65,7 @@ export async function fetchRecentBtcBlocks(chain: string, api?: string) {
   const response = await stacksAPIFetch(`${apiUrl}/extended/v2/burn-blocks/?limit=30&offset=0`, {
     cache: 'default',
     next: {
-      revalidate: 300, // 5 minutes
+      revalidate: 10, // 10 seconds
       tags: ['btc-blocks'],
     },
   });

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,6 +1,5 @@
 import { FeeSection } from '@/app/_components/FeeSection';
 import { MempoolSection } from '@/app/_components/MempoolSection';
-import { DEFAULT_MAINNET_SERVER } from '@/common/constants/env';
 import { NetworkModes } from '@/common/types/network';
 import { logError } from '@/common/utils/error-utils';
 import { SampleTxsFeeEstimate, getSampleTxsFeeEstimate } from '@/common/utils/fee-utils';

--- a/src/common/components/table/table-examples/TxsTable.tsx
+++ b/src/common/components/table/table-examples/TxsTable.tsx
@@ -9,8 +9,7 @@ import { useConfirmedTransactions } from '@/common/queries/useConfirmedTransacti
 import { formatTimestamp, formatTimestampToRelativeTime } from '@/common/utils/time-utils';
 import { getAmount, getToAddress } from '@/common/utils/transaction-utils';
 import { validateStacksContractId } from '@/common/utils/utils';
-import { Text } from '@/ui/Text';
-import { Box, Table as ChakraTable, Flex, Icon } from '@chakra-ui/react';
+import { Flex, Icon } from '@chakra-ui/react';
 import { ArrowRight } from '@phosphor-icons/react';
 import { useQueryClient } from '@tanstack/react-query';
 import { ColumnDef, Header, PaginationState } from '@tanstack/react-table';

--- a/src/common/queries/useBlockListInfinite.ts
+++ b/src/common/queries/useBlockListInfinite.ts
@@ -1,5 +1,4 @@
 import {
-  UseInfiniteQueryOptions,
   UseQueryResult,
   useInfiniteQuery,
   useQuery,

--- a/src/common/queries/useBurnBlocksInfinite.ts
+++ b/src/common/queries/useBurnBlocksInfinite.ts
@@ -19,6 +19,26 @@ import { TWO_MINUTES } from './query-stale-time';
 
 export const BURN_BLOCKS_QUERY_KEY = 'burnBlocks';
 
+export function getBurnBlocksQueryKey({
+  limit,
+  offset,
+  networkUrl,
+  queryKeyExtension,
+}: {
+  limit?: number;
+  offset?: number;
+  networkUrl?: string;
+  queryKeyExtension?: string;
+}) {
+  return [
+    BURN_BLOCKS_QUERY_KEY,
+    ...(limit ? [limit] : []),
+    ...(offset ? [offset] : []),
+    ...(networkUrl ? [networkUrl] : []),
+    ...(queryKeyExtension ? [queryKeyExtension] : []),
+  ];
+}
+
 export function useBurnBlocksInfinite(
   limit = DEFAULT_BURN_BLOCKS_LIMIT,
   options: any = {},
@@ -71,12 +91,7 @@ export function useBurnBlocks(
 ): UseQueryResult<GenericResponseType<BurnBlock>> {
   const apiClient = useApiClient();
   return useQuery({
-    queryKey: [
-      BURN_BLOCKS_QUERY_KEY,
-      limit,
-      ...(offset ? [offset] : []),
-      ...(queryKeyExtension ? [queryKeyExtension] : []),
-    ],
+    queryKey: getBurnBlocksQueryKey({ limit, offset, queryKeyExtension }),
     queryFn: async () => {
       return await callApiWithErrorHandling(apiClient, '/extended/v2/burn-blocks/', {
         params: { query: { limit, offset } },


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [ ] Refactor
- [ ] Feature
- [X] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
Fixes the problem with the recent blocks widget where the stacks blocks section doesn't start a blocks subscrption.
I think there were a number of issues: no memoizing, using infinity, and trying to maintain two blocks subscriptions at the same time.
What I've done is combine all the data and subscription logic for the btc blocks and stacks blocks section into one hook.
This makes it easier to see how the subscription is being handled and to ensure there is only one happening at any single point in time.

## Issue ticket number and link

# Checklist:
- [X] I have performed a self-review of my code.
- [X] I have tested the change on desktop and mobile.
- [ ] I have added thorough tests where applicable.
- [ ] I've added analytics and error logging where applicable.

## Screenshots (if appropriate):
<!--- Add screenshots of your changes -->
