### PR TITLE
fix: fixed stx block time which was burn block time

### DIFF
--- a/src/app/blocks/components/hooks/useBlocksTableData.ts
+++ b/src/app/blocks/components/hooks/useBlocksTableData.ts
@@ -88,7 +88,7 @@ export function useStacksTableData(
           hash: block.hash || '',
           transactions: block.tx_count ?? 0,
           totalFees: (block.execution_cost_read_count ?? 0).toString(),
-          timestamp: block.burn_block_time || 0,
+          timestamp: block.block_time || 0,
         } as StacksBlockTableData);
       });
     });


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [ ] Refactor
- [ ] Feature
- [X] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
The timestamp for stx blocks on the blocks page was using the burn block time

## Issue ticket number and link

# Checklist:
- [X] I have performed a self-review of my code.
- [X] I have tested the change on desktop and mobile.
- [ ] I have added thorough tests where applicable.
- [ ] I've added analytics and error logging where applicable.

## Screenshots (if appropriate):
<!--- Add screenshots of your changes -->
