### PR TITLE
fix: type handling and ref forwarding for ButtonLink component

### DIFF
--- a/src/ui/ButtonLink.tsx
+++ b/src/ui/ButtonLink.tsx
@@ -33,7 +33,14 @@ interface ButtonVariantProps
 
 type ButtonLinkProps = LinkVariantProps | ButtonVariantProps;
 
-const ButtonLinkBase = forwardRef<HTMLElement, ButtonLinkProps>(
+function isButtonProps(props: ButtonLinkProps): props is ButtonVariantProps {
+  return props.buttonLinkType === 'button';
+}
+
+const ButtonLinkBase = forwardRef<
+  HTMLButtonElement | HTMLAnchorElement,
+  ButtonLinkProps
+>(
   (
     {
       children,
@@ -44,8 +51,11 @@ const ButtonLinkBase = forwardRef<HTMLElement, ButtonLinkProps>(
     },
     ref
   ) => {
+    const ArrowIcon = buttonLinkDirection === 'forward' ? ArrowRight : ArrowLeft;
+
     const arrowIcon = (
       <Icon
+        as={ArrowIcon}
         w={buttonLinkSize === 'big' ? 3.5 : 3}
         h={buttonLinkSize === 'big' ? 3.5 : 3}
         color="iconTertiary"
@@ -53,9 +63,7 @@ const ButtonLinkBase = forwardRef<HTMLElement, ButtonLinkProps>(
           color: 'iconPrimary',
         }}
         aria-hidden="true"
-      >
-        {buttonLinkDirection === 'forward' ? <ArrowRight /> : <ArrowLeft />}
-      </Icon>
+      />
     );
 
     const content = (
@@ -73,8 +81,8 @@ const ButtonLinkBase = forwardRef<HTMLElement, ButtonLinkProps>(
     );
 
     // Button variant
-    if (buttonLinkType === 'button') {
-      const { onClick, ...buttonProps } = props as ButtonVariantProps;
+    if (isButtonProps(props)) {
+      const { onClick, ...buttonProps } = props;
       return (
         <Button
           ref={ref as React.Ref<HTMLButtonElement>}
@@ -88,7 +96,7 @@ const ButtonLinkBase = forwardRef<HTMLElement, ButtonLinkProps>(
     }
 
     // Link variant (default)
-    const { href, ...linkProps } = props as LinkVariantProps;
+    const { href, ...linkProps } = props;
     const isExternal = href?.startsWith('http');
 
     return isExternal ? (


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

I've cleaned up type handling and ref forwarding in `ButtonLink` to eliminate TypeScript warnings and make the component safer to use.

**chngs:**

* updated `forwardRef` to `forwardRef<HTMLButtonElement | HTMLAnchorElement, ButtonLinkProps>` so refs work correctly for both buttons and links.
* added a type guard `isButtonProps(props: ButtonLinkProps): props is ButtonVariantProps` to safely destructure props without `as` casting.
* switched Icon usage to `<Icon as={ArrowIcon} />` instead of nested JSX to ensure Chakra UI renders correctly and types are respected.

these changes remove TS errors and make the component more predictable when used in different contexts.

# Checklist:
- [x] I have performed a self-review of my code.
- [x] I have tested the change on desktop and mobile.
- [ ] I have added thorough tests where applicable.
- [ ] I've added analytics and error logging where applicable.

## Screenshots (if appropriate):
na
