### PR TITLE
fix: contract ids can be searched via tx id page

### DIFF
--- a/src/app/txid/[txId]/page-data.ts
+++ b/src/app/txid/[txId]/page-data.ts
@@ -1,9 +1,16 @@
 import { stacksAPIFetch } from '@/api/stacksAPIFetch';
 
-import { MempoolTransaction, Transaction } from '@stacks/stacks-blockchain-api-types';
+import {
+  MempoolTransaction,
+  SmartContract,
+  Transaction,
+} from '@stacks/stacks-blockchain-api-types';
 
 export const getTxTag = (txId: string) => `tx-id-${txId}`;
+export const getContractTag = (contractId: string) => `contract-id-${contractId}`;
+
 const CONFIRMED_TX_REVALIDATION_TIMEOUT_IN_SECONDS = 3; // 3 seconds
+const CONFIRMED_CONTRACT_REVALIDATION_TIMEOUT_IN_SECONDS = 3; // 3 seconds
 
 export async function fetchTxById(
   apiUrl: string,
@@ -19,4 +26,20 @@ export async function fetchTxById(
 
   const tx: Transaction | MempoolTransaction = await response.json();
   return tx;
+}
+
+export async function fetchContractById(
+  apiUrl: string,
+  contractId: string
+): Promise<SmartContract> {
+  const response = await stacksAPIFetch(`${apiUrl}/extended/v1/contract/${contractId}`, {
+    cache: 'default',
+    next: {
+      revalidate: CONFIRMED_CONTRACT_REVALIDATION_TIMEOUT_IN_SECONDS,
+      tags: [getContractTag(contractId)],
+    },
+  });
+
+  const contract: SmartContract = await response.json();
+  return contract;
 }


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [ ] Refactor
- [ ] Feature
- [X] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
There was a regression on the tx id page. Previously one could search for contract deployment tx id pages by entering the contract address into the tx id url param.

The code on the page client used to have [this](https://github.com/stx-labs/explorer/commit/8f8ba896473f17868761b06595979d3b50010162#diff-0653c836de6471c0458d0a41dc9cc9bc213f9abe87b24b18033fad077354648e):

```
  const isContractId = txId.includes('.');
  if (isContractId) {
    return <SmartContract contractId={txId} />;
  }
```

I removed that page. It looked like [this](https://github.com/stx-labs/explorer/commit/645c993f944bb8aaadb63e54a227e6a14c6a1bbd#diff-e5a1fe7a08e91f49220960ab1dbdb021177384119baf2ea77b56c938fed237ab):

```
export default function SmartContract({ contractId }: { contractId: string }) {
  const { data: contract } = useContractById(contractId);
  const { data: tx } = useTxById(contract?.tx_id);
  const source = contract?.source_code;

  if (tx?.tx_type !== 'smart_contract') return null;

  return (
    <TxPage tx={tx} contractId={contractId} txDetails={<TxDetails tx={tx} />}>
      <PostConditions tx={tx} />
      <ContractTabs source={source} contract={contract} contractId={contractId} />
      <AddressTxListTabs address={contractId} />
    </TxPage>
  );
}
```

You can see we take the contract id and query for its contract data to find its txid. Once we have the tx id, we can treat it just like all the other tx id pages. In this case, the tx id should be pointing to a tx with a tx type of "smart_contract".

I cover this case on the server, in our page component.

## Issue ticket number and link
https://stackslabs.slack.com/archives/C09EQ23D33M/p1760717530781249

# Checklist:
- [X] I have performed a self-review of my code.
- [X] I have tested the change on desktop and mobile.
- [ ] I have added thorough tests where applicable.
- [ ] I've added analytics and error logging where applicable.

## Screenshots (if appropriate):
<!--- Add screenshots of your changes -->
