### PR TITLE
fix: fixed address tx tab shoing 3 results

### DIFF
--- a/src/app/address/[principal]/redesign/AddressOverview.tsx
+++ b/src/app/address/[principal]/redesign/AddressOverview.tsx
@@ -9,7 +9,7 @@ import { Circle } from '@/common/components/Circle';
 import { BurnBlockLink } from '@/common/components/ExplorerLinks';
 import { StackingCardItem } from '@/common/components/id-pages/Overview';
 import { AddressTxsTable } from '@/common/components/table/table-examples/AddressTxsTable';
-import { DEFAULT_RECENT_ADDRESS_TXS_LIMIT } from '@/common/components/table/table-examples/consts';
+import { ADDRESS_ID_PAGE_RECENT_ADDRESS_TXS_LIMIT } from '@/common/components/table/table-examples/consts';
 import { getFtDecimalAdjustedBalance, microToStacks } from '@/common/utils/utils';
 import { SimpleTag } from '@/ui/Badge';
 import { NextLink } from '@/ui/NextLink';
@@ -414,7 +414,7 @@ export const AddressOverview = () => {
             principal={principal}
             initialData={initialAddressRecentTransactionsData}
             disablePagination
-            pageSize={DEFAULT_RECENT_ADDRESS_TXS_LIMIT}
+            pageSize={ADDRESS_ID_PAGE_RECENT_ADDRESS_TXS_LIMIT}
           />
         </Stack>
       </Stack>


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [ ] Refactor
- [ ] Feature
- [X] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
Fixed the address tx tab showing 3 results. The overview address tx table was erroneously using the same page size as the address tx tab table, resulting in them both using the initial data from the cache

## Issue ticket number and link
https://linear.app/stackslabs/issue/EXP-177/tx-list-on-the-address-page-only-shows-3-results

# Checklist:
- [X] I have performed a self-review of my code.
- [X] I have tested the change on desktop and mobile.
- [ ] I have added thorough tests where applicable.
- [ ] I've added analytics and error logging where applicable.

## Screenshots (if appropriate):
<!--- Add screenshots of your changes -->
