### PR TITLE
fix: prevent horizontal layout shifts when switching tabs (#2661)

### DIFF
--- a/src/app/global.css
+++ b/src/app/global.css
@@ -4,6 +4,10 @@ body {
   color: var(--stacks-colors-text);
 }
 
+html {
+  scrollbar-gutter: stable;
+}
+
 .prism-code *::selection {
   background-color: #aab3ff;
   color: white !important;


### PR DESCRIPTION
@andresgalante-stacks @stackslabs-admin @ginny-stacks 
## What type of PR is this? (check all applicable)
- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
This PR fixes a horizontal layout shift (content "jumping") that occurs when switching between tabs on address pages. The shift was caused by the viewport width changing whenever a vertical scrollbar appeared or disappeared between tabs of varying content lengths.

I have implemented the proposed solution by adding scrollbar-gutter: stable to the global styles. This reserves space for the scrollbar at all times, ensuring layout stability regardless of content overflow.

Following the project's contribution guidelines, I have also included a mandatory workplan for this task.

## Issue ticket number and link
Fixes #2661 Link: https://github.com/stx-labs/explorer/issues/2661

# Checklist:
- [x] I have performed a self-review of my code.
- [x] I have tested the change on desktop and mobile.
- [ ] I have added thorough tests where applicable.
- [ ] I've added analytics and error logging where applicable.

## Screenshots (if appropriate):
<!--- Add screenshots of your changes -->
