### PR TITLE
fix: prevent horizontal layout shift when switching tabs

### DIFF
--- a/src/app/global.css
+++ b/src/app/global.css
@@ -1,3 +1,7 @@
+html {
+  scrollbar-gutter: stable;
+}
+
 html,
 body {
   height: 100%;


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
Adds `scrollbar-gutter: stable` to prevent horizontal layout shift when switching between tabs on address pages. The shift was caused by the viewport width changing when a vertical scrollbar appeared or disappeared between tabs of varying content lengths.

## Issue ticket number and link
closes #2661

# Checklist:
- [x] I have performed a self-review of my code.
- [x] I have tested the change on desktop and mobile.
- [ ] I have added thorough tests where applicable.
- [ ] I've added analytics and error logging where applicable.