### PR TITLE
fix: remove semantic-release git plugin that fails on branch protection

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,7 @@
 # PRs:
 #   - Builds Explorer (no package push)
 # Pushes to main:
-#   - Builds Explorer
-#   - Pushes Docker image to GitHub Container Registry
+#   - Builds Explorer and pushes Docker image to GHCR
 #   - Creates attestations for supply chain security
 
 name: CI
@@ -49,9 +48,6 @@ jobs:
           SEMANTIC_RELEASE_PACKAGE: ${{ github.event.repository.name }}
         with:
           semantic_version: 19
-          extra_plugins: |
-            @semantic-release/changelog
-            @semantic-release/git
 
 
       - name: Set up Docker Buildx

--- a/package.json
+++ b/package.json
@@ -162,14 +162,7 @@
     "plugins": [
       "@semantic-release/commit-analyzer",
       "@semantic-release/release-notes-generator",
-      "@semantic-release/github",
-      "@semantic-release/changelog",
-      [
-        "@semantic-release/git",
-        {
-          "message": "chore(release): ${nextRelease.version}\n\n${nextRelease.notes}"
-        }
-      ]
+      "@semantic-release/github"
     ]
   },
   "resolutions": {


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
remove `@semantic-release/git` and `@semantic-release/changelog` plugins that try to push directly to main which has been failing since september due to branch protection rules. Release notes are still generated via `@semantic-release/github` on the gitHub releases page.

## Issue ticket number and link

# Checklist:
- [x] I have performed a self-review of my code.
- [x] I have tested the change on desktop and mobile.
- [ ] I have added thorough tests where applicable.
- [ ] I've added analytics and error logging where applicable.

## Screenshots (if appropriate):