### PR TITLE
fix: display uint values as integers without decimal points

### DIFF
--- a/src/app/txid/[txId]/redesign/function-called/__tests__/function-called-utils.test.ts
+++ b/src/app/txid/[txId]/redesign/function-called/__tests__/function-called-utils.test.ts
@@ -187,11 +187,6 @@ jest.mock('@stacks/transactions', () => ({
   hexToCV: jest.fn(),
 }));
 
-// Mock microToStacksFormatted since we're testing functions that use it
-jest.mock('@/common/utils/utils', () => ({
-  microToStacksFormatted: jest.fn(),
-}));
-
 describe('Function Called Utils', () => {
   // Reset mocks before each test
   beforeEach(() => {
@@ -285,7 +280,7 @@ describe('Function Called Utils', () => {
       });
     });
 
-    it('handles uint values correctly', () => {
+    it('handles uint values as integers without decimals', () => {
       const result = formatClarityValue({
         type: 'uint',
         repr: 'u1000',
@@ -293,16 +288,12 @@ describe('Function Called Utils', () => {
 
       expect(result).toEqual({
         name: '',
-        value: '1000',
+        value: '1,000',
         type: 'Unsigned Integer',
       });
     });
 
-    it('handles ustx values correctly', () => {
-      // Mock the microToStacksFormatted function specifically for this test
-      const mockMicroToStacks = require('@/common/utils/utils').microToStacksFormatted;
-      mockMicroToStacks.mockReturnValue('1');
-
+    it('handles ustx uint values as integers without STX conversion', () => {
       const result = formatClarityValue({
         type: 'uint',
         repr: 'u1000000',
@@ -311,12 +302,9 @@ describe('Function Called Utils', () => {
 
       expect(result).toEqual({
         name: 'amount-ustx',
-        value: '1',
+        value: '1,000,000',
         type: 'Unsigned Integer',
       });
-
-      // Verify that microToStacksFormatted was called with the correct value
-      expect(mockMicroToStacks).toHaveBeenCalledWith('1000000');
     });
 
     it('handles tuple values correctly', () => {

--- a/src/app/txid/[txId]/redesign/function-called/utils.ts
+++ b/src/app/txid/[txId]/redesign/function-called/utils.ts
@@ -1,5 +1,4 @@
 import { Singleton } from '@/common/types/utils';
-import { microToStacksFormatted } from '@/common/utils/utils';
 
 import {
   ContractCallTransaction,
@@ -81,11 +80,9 @@ export function formatClarityValue(cv: ClarityValue): FormattedClarityValue {
     value = isContract ? principal : principal || cv.repr.toString().replace(/^'/, '');
   }
   if (cv.type === 'uint' && typeof cv.repr === 'string') {
-    value = cv.repr.replace('u', '');
-    if (cv.name?.includes('ustx')) {
-      value = microToStacksFormatted(value);
-    }
-    value = value.toLocaleString();
+    value = Number(cv.repr.replace('u', '')).toLocaleString(undefined, {
+      maximumFractionDigits: 0,
+    });
   }
   if (cv.type.includes('tuple') && typeof cv.repr === 'string') {
     value = formatTupleResult(cv.repr);


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
display uint values in the function call arguments table as whole integers with thousands separators instead of converting ustx values to stx with decimal point.

## Issue ticket number and link
closes #2710

# Checklist:
- [x] I have performed a self-review of my code.
- [x] I have tested the change on desktop and mobile.
- [x] I have added thorough tests where applicable.
- [ ] I've added analytics and error logging where applicable.