### PR TITLE
fix: sort events table by event_index in ascending order

### DIFF
--- a/src/app/txid/[txId]/redesign/events-table/EventsTable.tsx
+++ b/src/app/txid/[txId]/redesign/events-table/EventsTable.tsx
@@ -218,7 +218,8 @@ export function EventsTable({
   const isTableFiltered = Object.values(filters).some(v => v != null && v !== '');
 
   const rowData: EventsTableData[] = useMemo(() => {
-    const rows = events.map((event, index) => {
+    const sortedEvents = [...events].sort((a, b) => a.event_index - b.event_index);
+    const rows = sortedEvents.map((event, index) => {
       const to = getToAddress(event);
       const from = getFromAddress(event);
       const amount = getAmount(event);
@@ -228,7 +229,7 @@ export function EventsTable({
       const contractLogPrintValue = getContractLogPrintValue(event);
 
       return {
-        [EventsTableColumns.Index]: Math.abs(event.event_index - numTxEvents),
+        [EventsTableColumns.Index]: event.event_index + 1,
         [EventsTableColumns.AssetEventType]: assetEventType,
         [EventsTableColumns.Asset]: asset,
         [EventsTableColumns.AssetType]: assetType,
@@ -251,7 +252,7 @@ export function EventsTable({
       };
     });
     return rows;
-  }, [events, numTxEvents]);
+  }, [events]);
 
   return (
     <Table


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
sort events table by event_index asc and use actual event_index for display numbers, fixing reversed event ordering that caused confusion when comparing with other explorers.

## Issue ticket number and link
closes #2709

# Checklist:
- [x] I have performed a self-review of my code.
- [ ] I have tested the change on desktop and mobile.
- [ ] I have added thorough tests where applicable.
- [ ] I've added analytics and error logging where applicable.