### PR TITLE
feat: pass devnet network string to @stacks/connect wallet calls

### DIFF
--- a/src/app/sandbox/components/ContractCall/FunctionView.tsx
+++ b/src/app/sandbox/components/ContractCall/FunctionView.tsx
@@ -19,6 +19,7 @@ import {
 
 import { Section } from '../../../../common/components/Section';
 import { useGlobalContext } from '../../../../common/context/useGlobalContext';
+import { getConnectNetworkString } from '../../../../common/utils/network-utils';
 import { showFn } from '../../../../common/utils/sandbox';
 import { Switch } from '../../../../components/ui/switch';
 import { Button } from '../../../../ui/Button';
@@ -196,7 +197,7 @@ export const FunctionView: FC<FunctionViewProps> = ({ fn, contractId, cancelButt
             contract: contractId,
             functionName: fn.name,
             functionArgs: Object.values(final),
-            network: network.mode,
+            network: getConnectNetworkString(network),
             postConditions:
               postConditionMode === PostConditionMode.Allow
                 ? undefined

--- a/src/app/sandbox/deploy/LeftSection.tsx
+++ b/src/app/sandbox/deploy/LeftSection.tsx
@@ -8,6 +8,7 @@ import { useCallback, useState } from 'react';
 import { useGlobalContext } from '../../../common/context/useGlobalContext';
 import { useRandomName } from '../../../common/hooks/useRandomName';
 import { useAppDispatch, useAppSelector } from '../../../common/state/hooks';
+import { getConnectNetworkString } from '../../../common/utils/network-utils';
 import { InputGroup } from '../../../components/ui/input-group';
 import { IconButton } from '../../../ui/IconButton';
 import { Input } from '../../../ui/Input';
@@ -30,7 +31,7 @@ export function LeftSection() {
     await deployContract({
       name: contractName,
       clarityCode: codeBody,
-      network: network.mode,
+      network: getConnectNetworkString(network),
     });
     void queryClient.invalidateQueries({ queryKey: ['addressMempoolTxsInfinite'] });
   }, [codeBody, contractName, network, queryClient]);

--- a/src/app/sandbox/transfer/PageClient.tsx
+++ b/src/app/sandbox/transfer/PageClient.tsx
@@ -9,6 +9,7 @@ import { Badge } from '../../../common/components/Badge';
 import { CONNECT_AUTH_ORIGIN } from '../../../common/constants/env';
 import { useGlobalContext } from '../../../common/context/useGlobalContext';
 import { useFeeTransfer } from '../../../common/queries/useFeeTransfer';
+import { getConnectNetworkString } from '../../../common/utils/network-utils';
 import { microToStacks, stacksToMicro, validateStacksAddress } from '../../../common/utils/utils';
 import { Button } from '../../../ui/Button';
 import { Input } from '../../../ui/Input';
@@ -54,7 +55,7 @@ const PageClient: NextPage = () => {
           recipient,
           amount: stacksToMicro(amount || 0).toString(),
           memo,
-          network: network.mode,
+          network: getConnectNetworkString(network),
         });
       }}
       render={({ handleChange, handleBlur, values, errors, setFieldValue }) => (

--- a/src/app/txid/[txId]/redesign/function-called/FunctionCallForm.tsx
+++ b/src/app/txid/[txId]/redesign/function-called/FunctionCallForm.tsx
@@ -4,6 +4,7 @@ import { ListValueType, ValueType } from '@/app/sandbox/types/values';
 import { Select } from '@/common/components/Select';
 import { useGlobalContext } from '@/common/context/useGlobalContext';
 import { logError } from '@/common/utils/error-utils';
+import { getConnectNetworkString } from '@/common/utils/network-utils';
 import { InvalidFunctionType, getInvalidFunctionType, showFn } from '@/common/utils/sandbox';
 import { Alert } from '@/components/ui/alert';
 import { Button } from '@/ui/Button';
@@ -120,7 +121,7 @@ export const FunctionCallForm: FC<FunctionCallFormProps> = ({
             await handlePublicFunctionCall(processedFunctionParams, postConditionParams, {
               contractId,
               fnAbi,
-              network: network.mode,
+              network: getConnectNetworkString(network),
               queryClient,
             });
           } else {

--- a/src/common/utils/__tests__/network-utils.test.ts
+++ b/src/common/utils/__tests__/network-utils.test.ts
@@ -1,4 +1,6 @@
-import { isHiroSubdomain, isLocalhost } from '../network-utils';
+import { DEFAULT_DEVNET_SERVER } from '../../constants/constants';
+import { Network, NetworkModes } from '../../types/network';
+import { getConnectNetworkString, isHiroSubdomain, isLocalhost } from '../network-utils';
 
 describe('getApiUrl', () => {
   const originalEnv = process.env;
@@ -158,5 +160,36 @@ describe('isHiroSubdomain', () => {
       expect(isHiroSubdomain('https://hiro.som')).toBe(false);
       expect(isHiroSubdomain('https://hero.so')).toBe(false);
     });
+  });
+});
+
+describe('getConnectNetworkString', () => {
+  const baseNetwork: Network = {
+    label: '',
+    url: '',
+    btcBlockBaseUrl: '',
+    btcTxBaseUrl: '',
+    btcAddressBaseUrl: '',
+    networkId: 1,
+    mode: NetworkModes.Mainnet,
+  };
+
+  it('should return "devnet" when the network URL matches DEFAULT_DEVNET_SERVER', () => {
+    const network = { ...baseNetwork, url: DEFAULT_DEVNET_SERVER, mode: NetworkModes.Testnet };
+    expect(getConnectNetworkString(network)).toBe('devnet');
+  });
+
+  it('should return network.mode for mainnet', () => {
+    const network = { ...baseNetwork, url: 'https://api.hiro.so', mode: NetworkModes.Mainnet };
+    expect(getConnectNetworkString(network)).toBe('mainnet');
+  });
+
+  it('should return network.mode for testnet', () => {
+    const network = {
+      ...baseNetwork,
+      url: 'https://api.testnet.hiro.so',
+      mode: NetworkModes.Testnet,
+    };
+    expect(getConnectNetworkString(network)).toBe('testnet');
   });
 });

--- a/src/common/utils/network-utils.ts
+++ b/src/common/utils/network-utils.ts
@@ -2,6 +2,17 @@ import { DEFAULT_DEVNET_SERVER } from '../constants/constants';
 import { DEFAULT_MAINNET_SERVER, DEFAULT_TESTNET_SERVER } from '../constants/env';
 import { Network, NetworkModes } from '../types/network';
 
+/**
+ * Returns the network string expected by @stacks/connect.
+ * Devnet uses testnet chain ID and mode, but @stacks/connect needs "devnet" as the network string.
+ */
+export function getConnectNetworkString(network: Network): string {
+  if (network.url === DEFAULT_DEVNET_SERVER) {
+    return 'devnet';
+  }
+  return network.mode;
+}
+
 export function getApiUrl(chain: string, customApiUrl?: string): string {
   if (customApiUrl) {
     return customApiUrl;


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
pass "devnet" instead of "testnet" to @stacks/connect wallet calls when on devnet, so contract calls, deployments, and transfers work correctly on devnet

## Issue ticket number and link

# Checklist:
- [x] I have performed a self-review of my code.
- [ ] I have tested the change on desktop and mobile.
- [x] I have added thorough tests where applicable.
- [ ] I've added analytics and error logging where applicable.

## Screenshots (if appropriate):