### PR TITLE
fix: skip eager availability check for localhost networks

### DIFF
--- a/src/app/_components/NewNavBar/NetworkSetting.tsx
+++ b/src/app/_components/NewNavBar/NetworkSetting.tsx
@@ -8,6 +8,7 @@ import { useCustomNetworkApiInfo } from '@/common/queries/useCustomNetworkApiInf
 import { useAppDispatch } from '@/common/state/hooks';
 import { Network } from '@/common/types/network';
 import { buildUrl } from '@/common/utils/buildUrl';
+import { isLocalhost } from '@/common/utils/network-utils';
 import { Button } from '@/components/ui/button';
 import { Link } from '@/ui/Link';
 import { Text } from '@/ui/Text';
@@ -85,8 +86,10 @@ const NetworkLabel = ({ network }: { network: Network }) => {
   const isDefault = isMainnet || isTestnet;
   const isDevnet = network.url === DEFAULT_DEVNET_SERVER;
 
+  const isLocalNetwork = isLocalhost(network.url);
+
   const { error, isFetching } = useCustomNetworkApiInfo(network.url, {
-    enabled: !!network.url && !isDefault,
+    enabled: !!network.url && !isDefault && !isLocalNetwork,
   });
   const isDisabled = isFetching || !!error;
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
skip the eager `/v2/info` fetch for localhost networks in the network dropdown to avoid triggering chrome private network access prompt on production

## Issue ticket number and link

# Checklist:
- [x] I have performed a self-review of my code.
- [x] I have tested the change on desktop and mobile.
- [ ] I have added thorough tests where applicable.
- [ ] I've added analytics and error logging where applicable.

## Screenshots (if appropriate):