### PR TITLE
fix: switch from socket.io to raw websocket for live updates

### DIFF
--- a/src/app/_components/BlockList/Sockets/__tests__/useSubscribeBlocks.test.ts
+++ b/src/app/_components/BlockList/Sockets/__tests__/useSubscribeBlocks.test.ts
@@ -2,7 +2,7 @@ import { renderHook } from '@testing-library/react';
 
 import { useSubscribeBlocks } from '../useSubscribeBlocks';
 
-const mockUnsubscribe = jest.fn();
+const mockUnsubscribe = jest.fn().mockResolvedValue(undefined);
 const mockDisconnect = jest.fn();
 const mockConnect = jest.fn();
 
@@ -16,7 +16,7 @@ jest.mock('../../../../../common/context/useGlobalContext', () => ({
     stacksApiSocketClientInfo: {
       connect: mockConnect.mockImplementation(handleConnect => {
         const mockClient = {
-          subscribeBlocks: jest.fn(() => mockSubscription),
+          subscribeBlocks: jest.fn().mockResolvedValue(mockSubscription),
         };
         handleConnect(mockClient);
       }),
@@ -30,13 +30,16 @@ describe('useSubscribeBlocks', () => {
     jest.clearAllMocks();
   });
 
-  it('calls unsubscribe and clears subscription on cleanup', () => {
+  it('calls unsubscribe and clears subscription on cleanup', async () => {
     const handleBlock = jest.fn();
 
     const { unmount } = renderHook(() => useSubscribeBlocks(true, handleBlock));
 
     // Verify subscription was created only once
     expect(mockConnect).toHaveBeenCalledTimes(1);
+
+    // Wait for async subscription to resolve
+    await new Promise(resolve => setTimeout(resolve, 0));
 
     // Unmount the hook
     unmount();

--- a/src/app/_components/BlockList/Sockets/__tests__/useSubscribeTxs.test.ts
+++ b/src/app/_components/BlockList/Sockets/__tests__/useSubscribeTxs.test.ts
@@ -2,7 +2,7 @@ import { renderHook } from '@testing-library/react';
 
 import { useSubscribeTxs } from '../useSubscribeTxs';
 
-const mockUnsubscribe = jest.fn();
+const mockUnsubscribe = jest.fn().mockResolvedValue(undefined);
 const mockDisconnect = jest.fn();
 const mockConnect = jest.fn();
 
@@ -16,7 +16,7 @@ jest.mock('../../../../../common/context/useGlobalContext', () => ({
     stacksApiSocketClientInfo: {
       connect: mockConnect.mockImplementation(handleConnect => {
         const mockClient = {
-          subscribeMempool: jest.fn(() => mockSubscription),
+          subscribeMempool: jest.fn().mockResolvedValue(mockSubscription),
         };
         handleConnect(mockClient);
       }),
@@ -30,13 +30,16 @@ describe('useSubscribeTxs', () => {
     jest.clearAllMocks();
   });
 
-  it('calls unsubscribe and clears subscription on cleanup', () => {
+  it('calls unsubscribe and clears subscription on cleanup', async () => {
     const handleTransaction = jest.fn();
 
     const { unmount } = renderHook(() => useSubscribeTxs(true, handleTransaction));
 
     // Verify subscription was created only once
     expect(mockConnect).toHaveBeenCalledTimes(1);
+
+    // Wait for async subscription to resolve
+    await new Promise(resolve => setTimeout(resolve, 0));
 
     // Unmount the hook
     unmount();

--- a/src/app/_components/BlockList/Sockets/use-stacks-api-socket-client.ts
+++ b/src/app/_components/BlockList/Sockets/use-stacks-api-socket-client.ts
@@ -1,65 +1,62 @@
 import { useCallback, useRef } from 'react';
 
-import { StacksApiSocketClient } from '@stacks/blockchain-api-client';
+import { StacksApiWebSocketClient } from '@stacks/blockchain-api-client';
 
 export interface StacksApiSocketClientInfo {
-  client: StacksApiSocketClient | null;
+  client: StacksApiWebSocketClient | null;
   connect: (
-    handleOnConnect?: (client: StacksApiSocketClient) => void,
+    handleOnConnect?: (client: StacksApiWebSocketClient) => void,
     handleError?: (error: Error) => void
   ) => void;
   disconnect: () => void;
 }
 
 export function useStacksApiSocketClient(apiUrl: string): StacksApiSocketClientInfo {
-  const socketClientRef = useRef<StacksApiSocketClient | null>(null);
-  const isSocketClientConnecting = useRef(false);
+  const clientRef = useRef<StacksApiWebSocketClient | null>(null);
+  const isConnecting = useRef(false);
+  const connectId = useRef(0);
 
   const disconnect = useCallback(() => {
-    if (socketClientRef.current?.socket.connected) {
-      socketClientRef.current.socket.removeAllListeners();
-      socketClientRef.current.socket.close();
-      socketClientRef.current = null;
-      isSocketClientConnecting.current = false;
+    connectId.current++;
+    if (clientRef.current) {
+      clientRef.current.webSocket.close();
+      clientRef.current = null;
     }
+    isConnecting.current = false;
   }, []);
 
   const connect = useCallback(
     async (
-      handleOnConnect?: (client: StacksApiSocketClient) => void,
+      handleOnConnect?: (client: StacksApiWebSocketClient) => void,
       handleError?: (error: Error) => void
     ) => {
       if (!apiUrl) return;
-      if (socketClientRef.current?.socket.connected || isSocketClientConnecting.current) {
+      if (clientRef.current || isConnecting.current) {
         return;
       }
+      const currentConnectId = ++connectId.current;
       try {
-        isSocketClientConnecting.current = true;
-        const client = await StacksApiSocketClient.connect({ url: apiUrl });
-        client.socket.on('connect', () => {
-          socketClientRef.current = client;
-          handleOnConnect?.(client);
-        });
-        client.socket.on('disconnect', () => {
-          client.socket.removeAllListeners();
-          client.socket.close();
-          disconnect();
-        });
-        client.socket.on('connect_error', error => {
-          client.socket.removeAllListeners();
-          client.socket.close();
-          disconnect();
-          handleError?.(error);
-        });
+        isConnecting.current = true;
+        const client = await StacksApiWebSocketClient.connect(apiUrl);
+        if (currentConnectId !== connectId.current) {
+          client.webSocket.close();
+          return;
+        }
+        clientRef.current = client;
+        isConnecting.current = false;
+        handleOnConnect?.(client);
       } catch (error) {
-        disconnect();
+        if (currentConnectId !== connectId.current) return;
+        isConnecting.current = false;
+        clientRef.current = null;
+        handleError?.(error instanceof Error ? error : new Error(String(error)));
       }
     },
     [apiUrl, disconnect]
   );
 
   return {
-    client: socketClientRef.current,
+    client: clientRef.current,
     connect,
     disconnect,
   };

--- a/src/app/_components/BlockList/Sockets/useSubscribeBlocks.ts
+++ b/src/app/_components/BlockList/Sockets/useSubscribeBlocks.ts
@@ -1,11 +1,11 @@
 import { useCallback, useEffect, useRef } from 'react';
 
-import { Block, NakamotoBlock, StacksApiSocketClient } from '@stacks/blockchain-api-client';
+import { Block, NakamotoBlock, StacksApiWebSocketClient } from '@stacks/blockchain-api-client';
 
 import { useGlobalContext } from '../../../../common/context/useGlobalContext';
 
 interface Subscription {
-  unsubscribe(): void;
+  unsubscribe(): Promise<void>;
 }
 
 export function useSubscribeBlocks(
@@ -26,8 +26,8 @@ export function useSubscribeBlocks(
   }, [disconnect]);
 
   useEffect(() => {
-    const subscribe = async (client: StacksApiSocketClient) => {
-      subscription.current = client?.subscribeBlocks(block => {
+    const subscribe = async (client: StacksApiWebSocketClient) => {
+      subscription.current = await client.subscribeBlocks(block => {
         handleBlock({
           ...(block as Block),
           parent_index_block_hash: '',

--- a/src/app/_components/BlockList/Sockets/useSubscribeTxs.ts
+++ b/src/app/_components/BlockList/Sockets/useSubscribeTxs.ts
@@ -1,11 +1,11 @@
 import { useCallback, useEffect, useRef } from 'react';
 
-import { MempoolTransaction, StacksApiSocketClient } from '@stacks/blockchain-api-client';
+import { MempoolTransaction, StacksApiWebSocketClient } from '@stacks/blockchain-api-client';
 
 import { useGlobalContext } from '../../../../common/context/useGlobalContext';
 
 interface Subscription {
-  unsubscribe(): void;
+  unsubscribe(): Promise<void>;
 }
 
 export function useSubscribeTxs(
@@ -26,11 +26,9 @@ export function useSubscribeTxs(
   }, [disconnect]);
 
   useEffect(() => {
-    const subscribe = async (client: StacksApiSocketClient) => {
-      subscription.current = client?.subscribeMempool(tx => {
-        handleTransaction({
-          ...tx,
-        });
+    const subscribe = async (client: StacksApiWebSocketClient) => {
+      subscription.current = await client.subscribeMempool(tx => {
+        handleTransaction(tx as unknown as MempoolTransaction);
       });
     };
 

--- a/src/common/context/GlobalContextProvider.tsx
+++ b/src/common/context/GlobalContextProvider.tsx
@@ -6,7 +6,7 @@ import { useCookies } from 'react-cookie';
 
 import { getApiClient } from '../../api/getApiClient';
 import {
-  StacksApiSocketClientInfo,
+  type StacksApiSocketClientInfo,
   useStacksApiSocketClient,
 } from '../../app/_components/BlockList/Sockets/use-stacks-api-socket-client';
 import { buildCustomNetworkUrl, fetchCustomNetworkId } from '../components/modals/AddNetwork/utils';


### PR DESCRIPTION
## What type of PR is this?
- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
switch from StacksApiSocketClient to StacksApiWebSocketClient for live updates. the socket.io endpoint on api.hiro.so is no longer connecting, while the raw websocket endpoint at /extended/v1/ws works fine.

## Issue ticket number and link

# Checklist:
- [x] I have performed a self-review of my code.
- [x] I have tested the change on desktop and mobile.
- [x] I have added thorough tests where applicable.
- [ ] I've added analytics and error logging where applicable.

## Screenshots (if appropriate):