### PR TITLE
fix: prefer metadata name over contract name for token display

### DIFF
--- a/src/app/token/[tokenId]/page-data.ts
+++ b/src/app/token/[tokenId]/page-data.ts
@@ -19,7 +19,7 @@ export async function getTokenDataFromStacksApi(
   try {
     const tokenMetadata = await fetchTokenMetadata(apiUrl, tokenId);
 
-    const name = safeGet(tokenMetadata?.name, tokenMetadata?.metadata?.name);
+    const name = safeGet(tokenMetadata?.metadata?.name, tokenMetadata?.name);
     const symbol = tokenMetadata?.symbol;
     const decimals = tokenMetadata?.decimals;
     const totalSupply = tokenMetadata?.total_supply;

--- a/src/app/token/[tokenId]/redesign/context/TokenIdPageContext.tsx
+++ b/src/app/token/[tokenId]/redesign/context/TokenIdPageContext.tsx
@@ -91,7 +91,7 @@ export function TokenIdPageDataProvider({
 
     return {
       ...ssrTokenData,
-      name: ssrTokenData?.name ?? ftMetadata?.name ?? ftMetadata?.metadata?.name,
+      name: ssrTokenData?.name ?? ftMetadata?.metadata?.name ?? ftMetadata?.name,
       symbol: ssrTokenData?.symbol ?? ftMetadata?.symbol,
       imageUri: ssrTokenData?.imageUri ?? ftMetadata?.image_uri,
       decimals,

--- a/src/common/components/table/fungible-tokens-table/FungibleTokensTable.tsx
+++ b/src/common/components/table/fungible-tokens-table/FungibleTokensTable.tsx
@@ -181,7 +181,7 @@ export function FungibleTokensTable({
         const tokenId = `${address}.${contract}`;
         const holding = calculateHoldingPercentage(ft.balance, ft.total_supply);
         const ticker = ft.symbol || deriveTokenTickerFromAssetId(tokenAssetId);
-        const name = ft.name || asset;
+        const name = ft.metadata?.name || ft.name || asset;
         const imageUrl = ft.metadata ? getTokenImageUrlFromTokenMetadata(ft.metadata) : undefined;
         const balance = ftDecimals(ft?.balance, ft?.decimals || 0);
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
prefer the metadata name over the contract name when displaying token names on the token detail page and address fungible tokens table

## Issue ticket number and link
closes #2528

# Checklist:
- [x] I have performed a self-review of my code.
- [x] I have tested the change on desktop and mobile.
- [ ] I have added thorough tests where applicable.
- [ ] I've added analytics and error logging where applicable.

## Screenshots (if appropriate):