### PR TITLE
fix: use server side sorting for mempool transactions table

### DIFF
--- a/src/common/components/table/Table.tsx
+++ b/src/common/components/table/Table.tsx
@@ -147,6 +147,9 @@ export type TableProps<T> = {
   getRowCanExpand?: (row: Row<T>) => boolean;
   expandAllRowsByDefault?: boolean;
   meta?: Record<string, unknown>;
+  manualSorting?: boolean;
+  initialSorting?: SortingState;
+  enableSortingRemoval?: boolean;
 };
 
 const ErrorTable = ({ error }: { error: string }) => {
@@ -247,8 +250,11 @@ export function Table<T>({
   expandAllRowsByDefault,
   renderSubComponent,
   meta,
+  manualSorting,
+  initialSorting,
+  enableSortingRemoval,
 }: TableProps<T>): JSX.Element {
-  const [sorting, setSorting] = useState<SortingState>([]);
+  const [sorting, setSorting] = useState<SortingState>(initialSorting ?? []);
   const [tableData, setTableData] = useState(data);
 
   const columnPinning = useMemo(() => getColumnPinningState(columns), [columns]);
@@ -287,6 +293,8 @@ export function Table<T>({
     getCoreRowModel: getCoreRowModel(),
     getExpandedRowModel: getExpandedRowModel(),
     getSortedRowModel: getSortedRowModel(),
+    manualSorting: manualSorting ?? false,
+    enableSortingRemoval: enableSortingRemoval ?? true,
     manualPagination: pagination?.manualPagination ?? false,
     ...(pagination
       ? pagination?.manualPagination

--- a/src/common/components/table/table-examples/MempoolTable.tsx
+++ b/src/common/components/table/table-examples/MempoolTable.tsx
@@ -14,7 +14,7 @@ import { validateStacksContractId } from '@/common/utils/utils';
 import { Flex } from '@chakra-ui/react';
 import { ArrowRight } from '@phosphor-icons/react';
 import { useQueryClient } from '@tanstack/react-query';
-import { ColumnDef, Header, PaginationState } from '@tanstack/react-table';
+import { ColumnDef, Header, PaginationState, SortingState } from '@tanstack/react-table';
 import { type JSX, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 import { MempoolTransaction, Transaction } from '@stacks/stacks-blockchain-api-types';
@@ -118,9 +118,21 @@ const defaultColumnDefinitions: ColumnDef<MempoolTableData>[] = [
     cell: ({ getValue, table }: { getValue: () => unknown; table: any }) => (
       <TimestampCell timestamp={getValue() as number} table={table} />
     ),
-    enableSorting: false,
+    enableSorting: true,
   },
 ];
+
+type MempoolSortField = 'age' | 'size' | 'fee';
+
+const COLUMN_TO_SORT_FIELD: Record<string, MempoolSortField> = {
+  [TxTableColumns.Fee]: 'fee',
+  [TxTableColumns.BlockTime]: 'age',
+};
+
+const SORT_FIELD_TO_COLUMN: Record<string, string> = {
+  fee: TxTableColumns.Fee,
+  age: TxTableColumns.BlockTime,
+};
 
 const TX_TABLE_PAGE_SIZE = 20;
 
@@ -143,6 +155,9 @@ export function MempoolTable({
   const queryClient = useQueryClient();
   const isCacheSetWithInitialData = useRef(false);
 
+  const [currentSort, setCurrentSort] = useState<MempoolSortField>(sort);
+  const [currentOrder, setCurrentOrder] = useState<'asc' | 'desc'>(order);
+
   const [pagination, setPagination] = useState<PaginationState>({
     pageIndex: 0,
     pageSize: TX_TABLE_PAGE_SIZE,
@@ -150,20 +165,20 @@ export function MempoolTable({
 
   const { fromAddress, toAddress } = filters || {};
 
-  // Reset pagination when filters change
+  // Reset pagination when filters or sort change
   useEffect(() => {
     setPagination(prev => ({
       ...prev,
       pageIndex: 0,
     }));
-  }, [fromAddress, toAddress]);
+  }, [fromAddress, toAddress, currentSort, currentOrder]);
 
   if (isCacheSetWithInitialData.current === false && initialData) {
     const queryKey = getMempoolTransactionsQueryKey(
       pagination.pageSize,
       pagination.pageIndex * pagination.pageSize,
-      sort,
-      order,
+      currentSort,
+      currentOrder,
       { fromAddress, toAddress }
     );
     queryClient.setQueryData(queryKey, initialData);
@@ -174,8 +189,8 @@ export function MempoolTable({
     pagination.pageSize,
     pagination.pageIndex * pagination.pageSize,
     { fromAddress, toAddress },
-    sort,
-    order,
+    currentSort,
+    currentOrder,
     {
       staleTime: THIRTY_SECONDS,
       gcTime: THIRTY_SECONDS,
@@ -238,10 +253,33 @@ export function MempoolTable({
     });
   }, [txs]);
 
+  const initialSorting = useMemo<SortingState>(
+    () => [{ id: SORT_FIELD_TO_COLUMN[sort], desc: order === 'desc' }],
+    [sort, order]
+  );
+
+  const handleSort = useCallback(
+    async (columnId: string | undefined, direction: 'asc' | 'desc' | undefined) => {
+      if (columnId && direction) {
+        const newSort = COLUMN_TO_SORT_FIELD[columnId];
+        if (newSort) {
+          setCurrentSort(newSort);
+          setCurrentOrder(direction);
+        }
+      }
+      return rowData;
+    },
+    [rowData]
+  );
+
   return (
     <Table
       data={rowData}
       columns={columnDefinitions ?? defaultColumnDefinitions}
+      manualSorting
+      initialSorting={initialSorting}
+      enableSortingRemoval={false}
+      onSort={handleSort}
       tableContainerWrapper={table => <TableContainer minH="500px">{table}</TableContainer>}
       scrollIndicatorWrapper={table => <ScrollIndicator>{table}</ScrollIndicator>}
       meta={


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
the mempool table fee and age column sorting now hits the API with `order_by`/`order` params instead of sorting the current page client side

## Issue ticket number and link

# Checklist:
- [x] I have performed a self-review of my code.
- [x] I have tested the change on desktop and mobile.
- [ ] I have added thorough tests where applicable.
- [ ] I've added analytics and error logging where applicable.