### PR TITLE
fix: label genesis block transactions in transaction title

### DIFF
--- a/src/common/utils/__tests__/transactions.test.ts
+++ b/src/common/utils/__tests__/transactions.test.ts
@@ -1,0 +1,29 @@
+import { getTxTitle } from '../transactions';
+
+describe('getTxTitle', () => {
+  it('should return genesis transfer label for block height 1 token transfers', () => {
+    const genesisTx: any = {
+      tx_type: 'token_transfer',
+      block_height: 1,
+      token_transfer: { amount: '0', recipient_address: 'ST1TEST' },
+    };
+    expect(getTxTitle(genesisTx)).toBe('Stacks 2.0 genesis transfer');
+  });
+
+  it('should return normal label for non-genesis token transfers', () => {
+    const normalTx: any = {
+      tx_type: 'token_transfer',
+      block_height: 500,
+      token_transfer: { amount: '1000000', recipient_address: 'ST1TEST' },
+    };
+    expect(getTxTitle(normalTx)).toBe('Send 1.00 STX');
+  });
+
+  it('should return normal label for mempool token transfers', () => {
+    const mempoolTx: any = {
+      tx_type: 'token_transfer',
+      token_transfer: { amount: '2000000', recipient_address: 'ST1TEST' },
+    };
+    expect(getTxTitle(mempoolTx)).toBe('Send 2.00 STX');
+  });
+});

--- a/src/common/utils/transactions.tsx
+++ b/src/common/utils/transactions.tsx
@@ -10,8 +10,10 @@ import {
   CoinbaseTransaction,
   MempoolCoinbaseTransaction,
   MempoolTenureChangeTransaction,
+  MempoolTokenTransferTransaction,
   MempoolTransaction,
   TenureChangeTransaction,
+  TokenTransferTransaction,
   Transaction,
 } from '@stacks/stacks-blockchain-api-types';
 
@@ -169,6 +171,12 @@ export const getTxTitle = (tx: Transaction | MempoolTransaction) => {
     case 'contract_call':
       return getFunctionName(tx);
     case 'token_transfer':
+      if (
+        isConfirmedTx<TokenTransferTransaction, MempoolTokenTransferTransaction>(tx) &&
+        tx.block_height === 1
+      ) {
+        return 'Stacks 2.0 genesis transfer';
+      }
       return `Send ${microToStacksFormatted(tx.token_transfer.amount)} STX`;
     case 'coinbase':
       return isConfirmedTx<CoinbaseTransaction, MempoolCoinbaseTransaction>(tx)

--- a/src/features/txs-list/TxTitle.tsx
+++ b/src/features/txs-list/TxTitle.tsx
@@ -4,6 +4,7 @@ import { MempoolTransaction, Transaction } from '@stacks/stacks-blockchain-api-t
 
 import { TxLink } from '../../common/components/ExplorerLinks';
 import { StxPrice } from '../../common/components/StxPrice';
+import { isConfirmedTx } from '../../common/utils/transactions';
 import { getContractName, getFunctionName, microToStacksFormatted } from '../../common/utils/utils';
 
 export const TxTitle = ({
@@ -44,6 +45,13 @@ export const TxTitle = ({
         </Flex>
       );
     case 'token_transfer':
+      if (isConfirmedTx(tx) && tx.block_height === 1) {
+        return (
+          <TxLink txId={tx.tx_id} openInNewTab={openInNewTab}>
+            Stacks 2.0 genesis transfer
+          </TxLink>
+        );
+      }
       return (
         <Flex flexDirection={['row']} alignItems={['center']}>
           <TxLink txId={tx.tx_id} openInNewTab={openInNewTab}>


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
label stacks 2.0 genesis block (block height 1) token transfers as "Stacks 2.0 genesis transfer" instead of "Send 0.00 STX"

## Issue ticket number and link
closes #383

# Checklist:
- [x] I have performed a self-review of my code.
- [x] I have tested the change on desktop and mobile.
- [x] I have added thorough tests where applicable.
- [ ] I've added analytics and error logging where applicable.