### PR TITLE
fix: add support for maybe_sent nft post-condition code

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "@sentry/nextjs": "10.44.0",
     "@sentry/profiling-node": "10.44.0",
     "@stacks/auth": "7.1.0",
-    "@stacks/blockchain-api-client": "8.13.0",
+    "@stacks/blockchain-api-client": "8.15.1",
     "@stacks/common": "7.0.2",
     "@stacks/connect": "8.1.9",
     "@stacks/connect-ui": "8.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -69,8 +69,8 @@ importers:
         specifier: 7.1.0
         version: 7.1.0
       '@stacks/blockchain-api-client':
-        specifier: 8.13.0
-        version: 8.13.0
+        specifier: 8.15.1
+        version: 8.15.1
       '@stacks/common':
         specifier: 7.0.2
         version: 7.0.2
@@ -2644,8 +2644,8 @@ packages:
   '@stacks/auth@7.1.0':
     resolution: {integrity: sha512-I2Wlk2ucM0roXSF7aDUThyLQan3PIkqC7QQ1ZL1ulorha7IraqubasJX8j/q/ZE58z9gQnPOf0ayf0r0ocNOuQ==}
 
-  '@stacks/blockchain-api-client@8.13.0':
-    resolution: {integrity: sha512-3JQcUwJ+mAz17DNi+yZpfV/HAaHYtW6dUshc0YUo1uLRE7QvRZUuDnodZkqoSGbPyqaJ6NFI2XP7MC2UiSedtA==}
+  '@stacks/blockchain-api-client@8.15.1':
+    resolution: {integrity: sha512-2JXZmQ6JXpri8QzAVQyddUVYKjp+RrmVlNvMVd9EgJZivvhrls/vJqUB5pVOxl/bHG1l/8Z4cvIOR3WGcyf5Zg==}
 
   '@stacks/common@6.16.0':
     resolution: {integrity: sha512-PnzvhrdGRMVZvxTulitlYafSK4l02gPCBBoI9QEoTqgSnv62oaOXhYAUUkTMFKxdHW1seVEwZsrahuXiZPIAwg==}
@@ -11285,7 +11285,7 @@ snapshots:
     transitivePeerDependencies:
       - encoding
 
-  '@stacks/blockchain-api-client@8.13.0':
+  '@stacks/blockchain-api-client@8.15.1':
     dependencies:
       '@types/node': 20.14.14
       eventemitter3: 4.0.7

--- a/src/app/txid/[txId]/redesign/post-conditions/PostConditionsTable.tsx
+++ b/src/app/txid/[txId]/redesign/post-conditions/PostConditionsTable.tsx
@@ -15,13 +15,13 @@ import { Flex } from '@chakra-ui/react';
 import { ColumnDef, Header } from '@tanstack/react-table';
 import { useMemo } from 'react';
 
+import type { Transaction } from '@stacks/blockchain-api-client';
 import {
   ContractCallTransaction,
   MempoolContractCallTransaction,
   MempoolSmartContractTransaction,
   PostCondition,
   PostConditionFungibleConditionCode,
-  PostConditionNonFungibleConditionCode,
   SmartContractTransaction,
 } from '@stacks/stacks-blockchain-api-types';
 
@@ -95,11 +95,14 @@ const columnDefinitions: ColumnDef<PostConditionsTableData>[] = [
   },
 ];
 
+type PostConditionNonFungibleConditionCode = Extract<
+  Transaction['post_conditions'][number],
+  { type: 'non_fungible' }
+>['condition_code'];
+
 type PostConditionConditionCode =
   | PostConditionFungibleConditionCode
-  | PostConditionNonFungibleConditionCode
-  // TODO: remove once @stacks/stacks-blockchain-api-types adds 'maybe_sent'
-  | 'maybe_sent';
+  | PostConditionNonFungibleConditionCode;
 
 function getPostConditionCellText(postConditionCode: PostConditionConditionCode): string {
   if (postConditionCode === 'sent_equal_to') {

--- a/src/app/txid/[txId]/redesign/post-conditions/PostConditionsTable.tsx
+++ b/src/app/txid/[txId]/redesign/post-conditions/PostConditionsTable.tsx
@@ -97,7 +97,9 @@ const columnDefinitions: ColumnDef<PostConditionsTableData>[] = [
 
 type PostConditionConditionCode =
   | PostConditionFungibleConditionCode
-  | PostConditionNonFungibleConditionCode;
+  | PostConditionNonFungibleConditionCode
+  // TODO: remove once @stacks/stacks-blockchain-api-types adds 'maybe_sent'
+  | 'maybe_sent';
 
 function getPostConditionCellText(postConditionCode: PostConditionConditionCode): string {
   if (postConditionCode === 'sent_equal_to') {
@@ -120,6 +122,9 @@ function getPostConditionCellText(postConditionCode: PostConditionConditionCode)
   }
   if (postConditionCode === 'not_sent') {
     return 'Must not transfer';
+  }
+  if (postConditionCode === 'maybe_sent') {
+    return 'May transfer';
   }
   return 'Undefined post condition code';
 }


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
fix: add support for maybe_sent nft post-condition code

## Issue ticket number and link
closes #2768

# Checklist:
- [x] I have performed a self-review of my code.
- [x] I have tested the change on desktop and mobile.
- [ ] I have added thorough tests where applicable.
- [ ] I've added analytics and error logging where applicable.

## Screenshots (if appropriate):

## Marketing Summary
Added support for the maybe_sent NFT post-condition introduced in Epoch 3.4 (SIP-040), which allows users to specify that an NFT may or may not be sent in a transaction — similar to the ≤ condition for fungible tokens.