### PR TITLE
feat: show data-var values on contract page

### DIFF
--- a/src/app/sandbox/__tests__/parseHexClarityValue.test.ts
+++ b/src/app/sandbox/__tests__/parseHexClarityValue.test.ts
@@ -4,15 +4,19 @@ import { parseHexClarityValue } from '../utils';
 
 describe('parseHexClarityValue', () => {
   it('parses a hex-prefixed clarity value', () => {
-    expect(parseHexClarityValue(cvToHex(uintCV(42)))).toBe('u42');
+    expect(parseHexClarityValue(cvToHex(uintCV(42)))).toEqual({ display: 'u42', parsed: true });
   });
 
   it('parses a hex string without 0x prefix', () => {
     const hex = cvToHex(uintCV(7)).slice(2);
-    expect(parseHexClarityValue(hex)).toBe('u7');
+    expect(parseHexClarityValue(hex)).toEqual({ display: 'u7', parsed: true });
   });
 
   it('parses optional none', () => {
-    expect(parseHexClarityValue(cvToHex(noneCV()))).toBe('none');
+    expect(parseHexClarityValue(cvToHex(noneCV()))).toEqual({ display: 'none', parsed: true });
+  });
+
+  it('returns the raw input and parsed=false on malformed hex', () => {
+    expect(parseHexClarityValue('not-hex')).toEqual({ display: 'not-hex', parsed: false });
   });
 });

--- a/src/app/sandbox/__tests__/parseHexClarityValue.test.ts
+++ b/src/app/sandbox/__tests__/parseHexClarityValue.test.ts
@@ -1,0 +1,18 @@
+import { cvToHex, noneCV, uintCV } from '@stacks/transactions';
+
+import { parseHexClarityValue } from '../utils';
+
+describe('parseHexClarityValue', () => {
+  it('parses a hex-prefixed clarity value', () => {
+    expect(parseHexClarityValue(cvToHex(uintCV(42)))).toBe('u42');
+  });
+
+  it('parses a hex string without 0x prefix', () => {
+    const hex = cvToHex(uintCV(7)).slice(2);
+    expect(parseHexClarityValue(hex)).toBe('u7');
+  });
+
+  it('parses optional none', () => {
+    expect(parseHexClarityValue(cvToHex(noneCV()))).toBe('none');
+  });
+});

--- a/src/app/sandbox/components/ContractCall/DataVariablesView.tsx
+++ b/src/app/sandbox/components/ContractCall/DataVariablesView.tsx
@@ -1,8 +1,6 @@
-'use client';
-
 import { Box, Flex, Grid, Icon, Spinner, Stack } from '@chakra-ui/react';
 import { Atom } from '@phosphor-icons/react';
-import { FC, useState } from 'react';
+import { FC, memo, useId, useState } from 'react';
 
 import { ClarityAbiType, getTypeString } from '@stacks/transactions';
 
@@ -23,8 +21,10 @@ interface AbiVariable {
 const DataVariableRow: FC<{
   contractId: string;
   variable: AbiVariable;
-}> = ({ contractId, variable }) => {
+}> = memo(function DataVariableRow({ contractId, variable }) {
   const [expanded, setExpanded] = useState(false);
+  const panelId = useId();
+  const labelId = useId();
   const network = useGlobalContext().activeNetwork;
 
   const { data, error, isLoading } = useDataVarValue({
@@ -38,13 +38,21 @@ const DataVariableRow: FC<{
 
   return (
     <Box>
-      <Flex
-        justifyContent="space-between"
-        p={4}
-        _hover={{ cursor: 'pointer', bg: 'surfaceHighlight' }}
+      <Box
+        as="button"
+        aria-expanded={expanded}
+        aria-controls={panelId}
         onClick={() => setExpanded(prev => !prev)}
-        w="full"
+        display="flex"
+        width="full"
+        justifyContent="space-between"
         alignItems="center"
+        p={4}
+        bg="transparent"
+        border="none"
+        textAlign="left"
+        cursor="pointer"
+        _hover={{ bg: 'surfaceHighlight' }}
       >
         <Flex alignItems="center" minW={0}>
           <Grid
@@ -54,13 +62,14 @@ const DataVariableRow: FC<{
             h={8}
             w={8}
             flexShrink={0}
+            aria-hidden="true"
           >
             <Icon h={4} w={4}>
               <Atom />
             </Icon>
           </Grid>
           <Box ml={4} minW={0}>
-            <Text fontSize="sm" fontFamily={`"Fira Code", monospace`} fontWeight="500">
+            <Text id={labelId} fontSize="sm" fontFamily="matterMono" fontWeight="500">
               {variable.name}
             </Text>
             <Text fontSize="xs" color="textSubdued" truncate>
@@ -69,35 +78,27 @@ const DataVariableRow: FC<{
           </Box>
         </Flex>
         <Text fontSize="xs" color="textSubdued" ml={4}>
-          {expanded ? 'Hide' : 'Fetch value'}
+          {isLoading ? 'Loading…' : expanded ? 'Hide' : 'Fetch value'}
         </Text>
-      </Flex>
+      </Box>
       {expanded && (
-        <Box px={4} pb={4}>
+        <Box id={panelId} role="region" aria-labelledby={labelId} px={4} pb={4}>
           {isLoading && (
             <Flex alignItems="center" justifyContent="center" py={4}>
               <Spinner size="sm" />
             </Flex>
           )}
           {error && (
-            <Text color="red" fontSize="sm">
+            <Text color="textError" fontSize="sm">
               {error instanceof Error ? error.message : 'Failed to fetch data variable value'}
             </Text>
           )}
-          {data && <CodeEditor code={safeParse(data.data)} />}
+          {data && <CodeEditor code={parseHexClarityValue(data.data).display} />}
         </Box>
       )}
     </Box>
   );
-};
-
-const safeParse = (hex: string): string => {
-  try {
-    return parseHexClarityValue(hex);
-  } catch {
-    return hex;
-  }
-};
+});
 
 export const DataVariablesView: FC<{
   contract: ContractWithParsedAbi;

--- a/src/app/sandbox/components/ContractCall/DataVariablesView.tsx
+++ b/src/app/sandbox/components/ContractCall/DataVariablesView.tsx
@@ -1,4 +1,4 @@
-import { Box, Flex, Grid, Icon, Spinner, Stack } from '@chakra-ui/react';
+import { Box, Flex, Grid, Icon, Spinner, Stack, chakra } from '@chakra-ui/react';
 import { Atom } from '@phosphor-icons/react';
 import { FC, memo, useId, useState } from 'react';
 
@@ -32,8 +32,8 @@ const DataVariableRow: FC<{
 
   return (
     <Box>
-      <Box
-        as="button"
+      <chakra.button
+        type="button"
         aria-expanded={expanded}
         aria-controls={panelId}
         onClick={() => setExpanded(prev => !prev)}
@@ -74,7 +74,7 @@ const DataVariableRow: FC<{
         <Text fontSize="xs" color="textSubdued" ml={4}>
           {isLoading ? 'Loading…' : expanded ? 'Hide' : 'Fetch value'}
         </Text>
-      </Box>
+      </chakra.button>
       {expanded && (
         <Box id={panelId} role="region" aria-labelledby={labelId} px={4} pb={4}>
           {isLoading && (

--- a/src/app/sandbox/components/ContractCall/DataVariablesView.tsx
+++ b/src/app/sandbox/components/ContractCall/DataVariablesView.tsx
@@ -2,7 +2,7 @@ import { Box, Flex, Grid, Icon, Spinner, Stack } from '@chakra-ui/react';
 import { Atom } from '@phosphor-icons/react';
 import { FC, memo, useId, useState } from 'react';
 
-import { ClarityAbiType, getTypeString } from '@stacks/transactions';
+import { ClarityAbiVariable, getTypeString } from '@stacks/transactions';
 
 import { Section } from '../../../../common/components/Section';
 import { useGlobalContext } from '../../../../common/context/useGlobalContext';
@@ -12,15 +12,9 @@ import { CodeEditor } from '../../../../ui/CodeEditor';
 import { Text } from '../../../../ui/Text';
 import { parseHexClarityValue } from '../../utils';
 
-interface AbiVariable {
-  name: string;
-  type: ClarityAbiType;
-  access: 'variable' | 'constant';
-}
-
 const DataVariableRow: FC<{
   contractId: string;
-  variable: AbiVariable;
+  variable: ClarityAbiVariable;
 }> = memo(function DataVariableRow({ contractId, variable }) {
   const [expanded, setExpanded] = useState(false);
   const panelId = useId();
@@ -104,7 +98,7 @@ export const DataVariablesView: FC<{
   contract: ContractWithParsedAbi;
   contractId: string;
 }> = ({ contract, contractId }) => {
-  const variables = (contract?.abi?.variables ?? []) as unknown as AbiVariable[];
+  const variables = (contract?.abi?.variables ?? []) as unknown as ClarityAbiVariable[];
   const dataVars = variables.filter(v => v.access === 'variable');
 
   if (dataVars.length === 0) return null;

--- a/src/app/sandbox/components/ContractCall/DataVariablesView.tsx
+++ b/src/app/sandbox/components/ContractCall/DataVariablesView.tsx
@@ -1,0 +1,120 @@
+'use client';
+
+import { Box, Flex, Grid, Icon, Spinner, Stack } from '@chakra-ui/react';
+import { Atom } from '@phosphor-icons/react';
+import { FC, useState } from 'react';
+
+import { ClarityAbiType, getTypeString } from '@stacks/transactions';
+
+import { Section } from '../../../../common/components/Section';
+import { useGlobalContext } from '../../../../common/context/useGlobalContext';
+import { useDataVarValue } from '../../../../common/queries/useDataVarValue';
+import { ContractWithParsedAbi } from '../../../../common/types/contract';
+import { CodeEditor } from '../../../../ui/CodeEditor';
+import { Text } from '../../../../ui/Text';
+import { parseHexClarityValue } from '../../utils';
+
+interface AbiVariable {
+  name: string;
+  type: ClarityAbiType;
+  access: 'variable' | 'constant';
+}
+
+const DataVariableRow: FC<{
+  contractId: string;
+  variable: AbiVariable;
+}> = ({ contractId, variable }) => {
+  const [expanded, setExpanded] = useState(false);
+  const network = useGlobalContext().activeNetwork;
+
+  const { data, error, isLoading } = useDataVarValue({
+    contractId,
+    varName: variable.name,
+    network,
+    enabled: expanded,
+  });
+
+  const typeLabel = getTypeString(variable.type);
+
+  return (
+    <Box>
+      <Flex
+        justifyContent="space-between"
+        p={4}
+        _hover={{ cursor: 'pointer', bg: 'surfaceHighlight' }}
+        onClick={() => setExpanded(prev => !prev)}
+        w="full"
+        alignItems="center"
+      >
+        <Flex alignItems="center" minW={0}>
+          <Grid
+            placeItems="center"
+            borderWidth="1px"
+            borderRadius="100%"
+            h={8}
+            w={8}
+            flexShrink={0}
+          >
+            <Icon h={4} w={4}>
+              <Atom />
+            </Icon>
+          </Grid>
+          <Box ml={4} minW={0}>
+            <Text fontSize="sm" fontFamily={`"Fira Code", monospace`} fontWeight="500">
+              {variable.name}
+            </Text>
+            <Text fontSize="xs" color="textSubdued" truncate>
+              {typeLabel}
+            </Text>
+          </Box>
+        </Flex>
+        <Text fontSize="xs" color="textSubdued" ml={4}>
+          {expanded ? 'Hide' : 'Fetch value'}
+        </Text>
+      </Flex>
+      {expanded && (
+        <Box px={4} pb={4}>
+          {isLoading && (
+            <Flex alignItems="center" justifyContent="center" py={4}>
+              <Spinner size="sm" />
+            </Flex>
+          )}
+          {error && (
+            <Text color="red" fontSize="sm">
+              {error instanceof Error ? error.message : 'Failed to fetch data variable value'}
+            </Text>
+          )}
+          {data && <CodeEditor code={safeParse(data.data)} />}
+        </Box>
+      )}
+    </Box>
+  );
+};
+
+const safeParse = (hex: string): string => {
+  try {
+    return parseHexClarityValue(hex);
+  } catch {
+    return hex;
+  }
+};
+
+export const DataVariablesView: FC<{
+  contract: ContractWithParsedAbi;
+  contractId: string;
+}> = ({ contract, contractId }) => {
+  const variables = (contract?.abi?.variables ?? []) as unknown as AbiVariable[];
+  const dataVars = variables.filter(v => v.access === 'variable');
+
+  if (dataVars.length === 0) return null;
+
+  return (
+    <Section title="Data variables" overflowY="auto" mt={4}>
+      <Stack>
+        {dataVars.map(variable => (
+          <DataVariableRow key={variable.name} contractId={contractId} variable={variable} />
+        ))}
+      </Stack>
+    </Section>
+  );
+};

--- a/src/app/sandbox/components/ContractCall/DataVariablesView.tsx
+++ b/src/app/sandbox/components/ContractCall/DataVariablesView.tsx
@@ -8,7 +8,6 @@ import { Section } from '../../../../common/components/Section';
 import { useGlobalContext } from '../../../../common/context/useGlobalContext';
 import { useDataVarValue } from '../../../../common/queries/useDataVarValue';
 import { ContractWithParsedAbi } from '../../../../common/types/contract';
-import { CodeEditor } from '../../../../ui/CodeEditor';
 import { Text } from '../../../../ui/Text';
 import { parseHexClarityValue } from '../../utils';
 
@@ -87,7 +86,21 @@ const DataVariableRow: FC<{
               {error instanceof Error ? error.message : 'Failed to fetch data variable value'}
             </Text>
           )}
-          {data && <CodeEditor code={parseHexClarityValue(data.data).display} />}
+          {data && (
+            <Box
+              as="pre"
+              fontFamily="matterMono"
+              fontSize="sm"
+              whiteSpace="pre-wrap"
+              wordBreak="break-all"
+              bg="surfaceHighlight"
+              p={3}
+              borderRadius="md"
+              m={0}
+            >
+              {parseHexClarityValue(data.data).display}
+            </Box>
+          )}
         </Box>
       )}
     </Box>

--- a/src/app/sandbox/components/ContractCall/SelectedContractView.tsx
+++ b/src/app/sandbox/components/ContractCall/SelectedContractView.tsx
@@ -18,6 +18,7 @@ import FunctionXIcon from '../../../../ui/icons/FunctionX';
 import { Caption, Title } from '../../../../ui/typography';
 import { selectShowRightPanel } from '../../sandbox-slice';
 import { AvailableFunctionsView } from './AvailableFunctionsView';
+import { DataVariablesView } from './DataVariablesView';
 import { FunctionView } from './FunctionView';
 import { PluralizedCaption } from './PluralizedCaption';
 
@@ -139,7 +140,10 @@ export const SelectedContractView: FC<{
             }
           />
         ) : (
-          <AvailableFunctionsView contract={contract} contractId={contractId} />
+          <>
+            <AvailableFunctionsView contract={contract} contractId={contractId} />
+            <DataVariablesView contract={contract} contractId={contractId} />
+          </>
         )}
       </Box>
     </Grid>

--- a/src/app/sandbox/utils.ts
+++ b/src/app/sandbox/utils.ts
@@ -7,6 +7,7 @@ import {
   cvToString,
   deserializeCV,
   encodeAbiClarityValue,
+  hexToCV,
   isClarityAbiOptional,
   isClarityAbiTuple,
   noneCV,
@@ -31,7 +32,7 @@ export interface ParsedHexClarityValue {
 
 export const parseHexClarityValue = (hex: string): ParsedHexClarityValue => {
   try {
-    return { display: cvToString(deserializeCV(hex)), parsed: true };
+    return { display: cvToString(hexToCV(hex)), parsed: true };
   } catch {
     return { display: hex, parsed: false };
   }

--- a/src/app/sandbox/utils.ts
+++ b/src/app/sandbox/utils.ts
@@ -24,9 +24,17 @@ export const parseReadOnlyResponse = ({ result }: ReadOnlyResponse) => {
   return cvToString(clarityValue);
 };
 
-export const parseHexClarityValue = (hex: string): string => {
-  const clarityValue = deserializeCV(hex);
-  return cvToString(clarityValue);
+export interface ParsedHexClarityValue {
+  display: string;
+  parsed: boolean;
+}
+
+export const parseHexClarityValue = (hex: string): ParsedHexClarityValue => {
+  try {
+    return { display: cvToString(deserializeCV(hex)), parsed: true };
+  } catch {
+    return { display: hex, parsed: false };
+  }
 };
 
 export const getTuple = (type?: ClarityAbiType): ClarityAbiTypeTuple['tuple'] | undefined => {

--- a/src/app/sandbox/utils.ts
+++ b/src/app/sandbox/utils.ts
@@ -24,6 +24,11 @@ export const parseReadOnlyResponse = ({ result }: ReadOnlyResponse) => {
   return cvToString(clarityValue);
 };
 
+export const parseHexClarityValue = (hex: string): string => {
+  const clarityValue = deserializeCV(hex);
+  return cvToString(clarityValue);
+};
+
 export const getTuple = (type?: ClarityAbiType): ClarityAbiTypeTuple['tuple'] | undefined => {
   if (!type) return;
   const isTuple = isClarityAbiTuple(type);

--- a/src/common/queries/__tests__/sanitizeErrorBody.test.ts
+++ b/src/common/queries/__tests__/sanitizeErrorBody.test.ts
@@ -1,0 +1,19 @@
+import { sanitizeErrorBody } from '../useDataVarValue';
+
+describe('sanitizeErrorBody', () => {
+  it('returns short bodies unchanged', () => {
+    expect(sanitizeErrorBody('not found')).toBe('not found');
+  });
+
+  it('truncates bodies over the size cap', () => {
+    const body = 'x'.repeat(3000);
+    const result = sanitizeErrorBody(body);
+    expect(result.length).toBe(2049);
+    expect(result.endsWith('…')).toBe(true);
+  });
+
+  it('strips control characters but keeps tab and newline', () => {
+    const body = 'line1\nline2\tvalue\x1B[31mred\x07\x00';
+    expect(sanitizeErrorBody(body)).toBe('line1\nline2\tvalue[31mred');
+  });
+});

--- a/src/common/queries/useDataVarValue.ts
+++ b/src/common/queries/useDataVarValue.ts
@@ -1,0 +1,67 @@
+import { UseQueryResult, useQuery } from '@tanstack/react-query';
+
+import { HIRO_HEADERS } from '../constants/env';
+import { Network } from '../types/network';
+
+export interface DataVarResponse {
+  data: string;
+  proof?: string;
+}
+
+interface DataVarOptions {
+  contractAddress: string;
+  contractName: string;
+  varName: string;
+  network: Network;
+}
+
+export const fetchDataVarValue = async ({
+  contractAddress,
+  contractName,
+  varName,
+  network,
+}: DataVarOptions): Promise<DataVarResponse> => {
+  const url = `${network.url}/v2/data_var/${contractAddress}/${contractName}/${encodeURIComponent(
+    varName
+  )}?proof=0`;
+
+  const response = await fetch(url, {
+    headers: {
+      ...HIRO_HEADERS,
+    },
+  });
+
+  if (!response.ok) {
+    const text = await response.text();
+    throw new Error(text || `Request failed with status ${response.status}`);
+  }
+
+  return response.json();
+};
+
+export function useDataVarValue({
+  contractId,
+  varName,
+  network,
+  enabled,
+}: {
+  contractId: string;
+  varName: string;
+  network: Network;
+  enabled: boolean;
+}): UseQueryResult<DataVarResponse> {
+  const [contractAddress, contractName] = contractId.split('.');
+
+  return useQuery({
+    queryKey: ['dataVar', contractId, varName, network.networkId],
+    queryFn: () =>
+      fetchDataVarValue({
+        contractAddress,
+        contractName,
+        varName,
+        network,
+      }),
+    enabled,
+    staleTime: 0,
+  });
+}

--- a/src/common/queries/useDataVarValue.ts
+++ b/src/common/queries/useDataVarValue.ts
@@ -67,7 +67,7 @@ export function useDataVarValue({
   const [contractAddress = '', contractName = ''] = isValid ? contractId.split('.') : [];
 
   return useQuery({
-    queryKey: ['dataVar', contractId, varName, network.networkId],
+    queryKey: ['dataVar', contractId, varName, network.networkId, network.url],
     queryFn: () =>
       fetchDataVarValue({
         contractAddress,

--- a/src/common/queries/useDataVarValue.ts
+++ b/src/common/queries/useDataVarValue.ts
@@ -2,6 +2,7 @@ import { UseQueryResult, useQuery } from '@tanstack/react-query';
 
 import { HIRO_HEADERS } from '../constants/env';
 import { Network } from '../types/network';
+import { validateStacksContractId } from '../utils/utils';
 
 export interface DataVarResponse {
   data: string;
@@ -15,15 +16,27 @@ interface DataVarOptions {
   network: Network;
 }
 
+const MAX_VAR_NAME_LENGTH = 128;
+const MAX_ERROR_BYTES = 2048;
+const CONTROL_CHARS = /[\x00-\x08\x0B\x0C\x0E-\x1F\x7F]/g;
+
+export const sanitizeErrorBody = (body: string): string => {
+  const truncated = body.length > MAX_ERROR_BYTES ? `${body.slice(0, MAX_ERROR_BYTES)}…` : body;
+  return truncated.replace(CONTROL_CHARS, '');
+};
+
 export const fetchDataVarValue = async ({
   contractAddress,
   contractName,
   varName,
   network,
 }: DataVarOptions): Promise<DataVarResponse> => {
-  const url = `${network.url}/v2/data_var/${contractAddress}/${contractName}/${encodeURIComponent(
-    varName
-  )}?proof=0`;
+  if (varName.length > MAX_VAR_NAME_LENGTH) {
+    throw new Error(`Variable name exceeds maximum length of ${MAX_VAR_NAME_LENGTH}`);
+  }
+  const url = `${network.url}/v2/data_var/${encodeURIComponent(
+    contractAddress
+  )}/${encodeURIComponent(contractName)}/${encodeURIComponent(varName)}?proof=0`;
 
   const response = await fetch(url, {
     headers: {
@@ -32,7 +45,7 @@ export const fetchDataVarValue = async ({
   });
 
   if (!response.ok) {
-    const text = await response.text();
+    const text = sanitizeErrorBody(await response.text());
     throw new Error(text || `Request failed with status ${response.status}`);
   }
 
@@ -50,7 +63,8 @@ export function useDataVarValue({
   network: Network;
   enabled: boolean;
 }): UseQueryResult<DataVarResponse> {
-  const [contractAddress, contractName] = contractId.split('.');
+  const isValid = validateStacksContractId(contractId);
+  const [contractAddress = '', contractName = ''] = isValid ? contractId.split('.') : [];
 
   return useQuery({
     queryKey: ['dataVar', contractId, varName, network.networkId],
@@ -61,7 +75,7 @@ export function useDataVarValue({
         varName,
         network,
       }),
-    enabled,
+    enabled: enabled && isValid,
     staleTime: 0,
   });
 }

--- a/src/common/queries/useDataVarValue.ts
+++ b/src/common/queries/useDataVarValue.ts
@@ -77,5 +77,6 @@ export function useDataVarValue({
       }),
     enabled: enabled && isValid,
     staleTime: 0,
+    gcTime: 0,
   });
 }


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Feature

## Description
show data-var values on contract page

## Issue ticket number and link
closes #2782

# Checklist:
- [x] I have performed a self-review of my code.
- [ ] I have tested the change on desktop and mobile.
- [x] I have added thorough tests where applicable.
- [ ] I've added analytics and error logging where applicable.

## Marketing Summary
You can now view the live values of a contract's data variables right from the sandbox. Just open any contract and click a variable to fetch its current on-chain value.