### PR TITLE
feat: restore pending transactions tab on address page

### DIFF
--- a/e2e/page-address.spec.ts
+++ b/e2e/page-address.spec.ts
@@ -42,4 +42,14 @@ test.describe('/address page', () => {
       });
     });
   });
+
+  test.describe('Pending tab', () => {
+    test('renders unconditionally and is reachable via ?tab=pending', async ({ page }) => {
+      const network = Object.keys(addresses)[0];
+      const type = Object.keys((addresses as any)[network])[0];
+      const address = (addresses as any)[network][type][0];
+      await page.goto(`/address/${address}?chain=${network}&tab=pending`);
+      await expect(page.getByRole('tab', { name: 'Pending' })).toBeVisible();
+    });
+  });
 });

--- a/e2e/page-address.spec.ts
+++ b/e2e/page-address.spec.ts
@@ -1,4 +1,5 @@
-import { expect, test, Page } from '@playwright/test';
+import { Page, expect, test } from '@playwright/test';
+
 import { addresses, emptyAddresses } from './addresses-test-vector';
 
 async function hasTransactions(page: Page) {
@@ -49,7 +50,9 @@ test.describe('/address page', () => {
       const type = Object.keys((addresses as any)[network])[0];
       const address = (addresses as any)[network][type][0];
       await page.goto(`/address/${address}?chain=${network}&tab=pending`);
-      await expect(page.getByRole('tab', { name: 'Pending' })).toBeVisible();
+      const pendingTab = page.getByRole('tab', { name: 'Pending' });
+      await expect(pendingTab).toBeVisible();
+      await expect(pendingTab).toHaveAttribute('aria-selected', 'true');
     });
   });
 });

--- a/src/app/address/[principal]/redesign/AddressTabs.tsx
+++ b/src/app/address/[principal]/redesign/AddressTabs.tsx
@@ -15,6 +15,7 @@ import {
 } from '@/common/components/table/table-examples/consts';
 import { useAddressTxs } from '@/common/queries/useAddressConfirmedTxsWithTransfersInfinite';
 import { useNftHoldings } from '@/common/queries/useNftHoldings';
+import { AddressMempoolTxsList } from '@/features/txs-list/AddressMempoolTxsList';
 import { TabsContent, TabsList, TabsRoot } from '@/ui/Tabs';
 import { useSearchParams } from 'next/navigation';
 import { useMemo, useState } from 'react';
@@ -26,6 +27,7 @@ import { NFTTable } from './NFTTable';
 enum AddressIdPageTab {
   Overview = 'overview',
   Transactions = 'transactions',
+  Pending = 'pending',
   Tokens = 'tokens',
   Collectibles = 'collectibles',
 }
@@ -95,6 +97,12 @@ export const AddressTabs = ({ principal }: { principal: string }) => {
               isActive={selectedTab === AddressIdPageTab.Transactions}
             />
           )}
+          <SectionTabsTrigger
+            key={AddressIdPageTab.Pending}
+            label={`Pending`}
+            value={AddressIdPageTab.Pending}
+            isActive={selectedTab === AddressIdPageTab.Pending}
+          />
           {totalAddressFungibleTokens > 0 && (
             <SectionTabsTrigger
               key={AddressIdPageTab.Tokens}
@@ -124,6 +132,9 @@ export const AddressTabs = ({ principal }: { principal: string }) => {
           pageSize={ADDRESS_ID_PAGE_ADDRESS_TXS_LIMIT}
           columnDefinitions={columnDefinitionsWithEvents}
         />
+      </TabsContent>
+      <TabsContent key={AddressIdPageTab.Pending} value={AddressIdPageTab.Pending}>
+        <AddressMempoolTxsList address={principal} />
       </TabsContent>
       <TabsContent key={AddressIdPageTab.Tokens} value={AddressIdPageTab.Tokens}>
         <FungibleTokensTableWithFilters


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Feature

## Description
restore pending transactions tab on address page

## Issue ticket number and link

# Checklist:
- [x] I have performed a self-review of my code.
- [ ] I have tested the change on desktop and mobile.
- [ ] I have added thorough tests where applicable.
- [ ] I've added analytics and error logging where applicable.

## Screenshots (if appropriate):

## Marketing Summary
The address page now surfaces pending transactions again in a dedicated tab, making it easy to see what's still in the mempool for any address.