### PR TITLE
feat: migrate homepage latest transactions to v3 endpoint

### DIFF
--- a/src/app/_components/TxsSection.tsx
+++ b/src/app/_components/TxsSection.tsx
@@ -3,19 +3,22 @@
 import { AddressLinkCellRenderer } from '@/common/components/table/CommonTableCellRenderers';
 import { DefaultTableColumnHeader } from '@/common/components/table/TableComponents';
 import {
+  TxSummaryTable,
+  TxSummaryTableData,
+} from '@/common/components/table/table-examples/TxSummaryTable';
+import {
   TimeStampCellRenderer,
-  TransactionTitleCellRenderer,
   TxLinkCellRenderer,
+  TxSummaryTitleCellRenderer,
   TxTypeCellRenderer,
 } from '@/common/components/table/table-examples/TxTableCellRenderers';
 import {
   TxTableAddressColumnData,
-  TxTableData,
-  TxsTable,
   defaultTableContainer,
 } from '@/common/components/table/table-examples/TxsTable';
 import { TxTableColumns } from '@/common/components/table/table-examples/types';
 import { useGlobalContext } from '@/common/context/useGlobalContext';
+import { TransactionSummary, TransactionSummaryListResponse } from '@/common/types/tx-v3';
 import { buildUrl } from '@/common/utils/buildUrl';
 import { formatTimestampLocalized, formatTimestampToRelativeTime } from '@/common/utils/time-utils';
 import { ButtonLink } from '@/ui/ButtonLink';
@@ -23,16 +26,14 @@ import { Text } from '@/ui/Text';
 import { Flex, Stack } from '@chakra-ui/react';
 import { ColumnDef, Header } from '@tanstack/react-table';
 
-import { MempoolTransaction, Transaction } from '@stacks/stacks-blockchain-api-types';
-
 import { TXS_LIST_SIZE } from '../consts';
 
-export const columnDefinitions: ColumnDef<TxTableData>[] = [
+export const columnDefinitions: ColumnDef<TxSummaryTableData>[] = [
   {
     id: TxTableColumns.Transaction,
     header: 'Transaction',
     accessorKey: TxTableColumns.Transaction,
-    cell: info => TransactionTitleCellRenderer(info.getValue() as Transaction | MempoolTransaction),
+    cell: info => TxSummaryTitleCellRenderer(info.getValue() as TransactionSummary),
     enableSorting: false,
   },
   {
@@ -65,7 +66,7 @@ export const columnDefinitions: ColumnDef<TxTableData>[] = [
   },
   {
     id: TxTableColumns.BlockTime,
-    header: ({ header }: { header: Header<TxTableData, unknown> }) => (
+    header: ({ header }: { header: Header<TxSummaryTableData, unknown> }) => (
       <Flex alignItems="center" justifyContent="flex-end" w="full">
         <DefaultTableColumnHeader header={header}>Timestamp</DefaultTableColumnHeader>
       </Flex>
@@ -84,7 +85,11 @@ export const columnDefinitions: ColumnDef<TxTableData>[] = [
   },
 ];
 
-export const TxsSection = ({ initialTxTableData }: { initialTxTableData: any }) => {
+export const TxsSection = ({
+  initialTxTableData,
+}: {
+  initialTxTableData: TransactionSummaryListResponse | undefined;
+}) => {
   const network = useGlobalContext().activeNetwork;
 
   return (
@@ -102,9 +107,8 @@ export const TxsSection = ({ initialTxTableData }: { initialTxTableData: any }) 
           View all transactions
         </ButtonLink>
       </Flex>
-      <TxsTable
+      <TxSummaryTable
         initialData={initialTxTableData}
-        disablePagination
         pageSize={TXS_LIST_SIZE}
         columnDefinitions={columnDefinitions}
         tableContainer={defaultTableContainer}

--- a/src/app/data.ts
+++ b/src/app/data.ts
@@ -1,9 +1,9 @@
-import { stacksAPIFetch } from '@/api/stacksAPIFetch';
+import { stacksAPIFetch, stacksAPIFetchJson } from '@/api/stacksAPIFetch';
 import { GenericResponseType } from '@/common/hooks/useInfiniteQueryResult';
 import { PoxInfo } from '@/common/queries/usePoxInforRaw';
+import { TransactionSummaryListResponse } from '@/common/types/tx-v3';
 import { NUM_TEN_MINUTES_IN_DAY } from '@/common/utils/consts';
 import { getApiUrl } from '@/common/utils/network-utils';
-import { CompressedTxTableData, compressTransactions } from '@/common/utils/transaction-utils';
 import { MICROSTACKS_IN_STACKS } from '@/common/utils/utils';
 
 import {
@@ -274,10 +274,15 @@ export async function fetchRecentBlocks(chain: string, api?: string): Promise<Re
   };
 }
 
-export async function fetchRecentTxs(chain: string, api?: string) {
+export async function fetchRecentUITxSummaries(
+  chain: string,
+  api?: string
+): Promise<TransactionSummaryListResponse> {
   const apiUrl = getApiUrl(chain, api);
-  const response = await stacksAPIFetch(
-    `${apiUrl}/extended/v1/tx/?limit=${TXS_LIST_SIZE}&offset=0`,
+  // stacksAPIFetchJson throws on non-2xx so an SSR error surfaces via page.tsx's catch/logError
+  // instead of seeding the query cache with an error body.
+  return await stacksAPIFetchJson<TransactionSummaryListResponse>(
+    `${apiUrl}/extended/v3/transactions?limit=${TXS_LIST_SIZE}`,
     {
       cache: 'default',
       next: {
@@ -286,19 +291,6 @@ export async function fetchRecentTxs(chain: string, api?: string) {
       },
     }
   );
-  return response;
-}
-
-export async function fetchRecentUITxs(
-  chain: string,
-  api?: string
-): Promise<CompressedTxTableData> {
-  const response = await fetchRecentTxs(chain, api);
-  const data = await response.json();
-  return {
-    ...data,
-    results: compressTransactions(data.results),
-  };
 }
 
 export async function fetchUIMempoolStats(chain: string, api?: string): Promise<UIMempoolStats> {

--- a/src/app/data.ts
+++ b/src/app/data.ts
@@ -279,8 +279,6 @@ export async function fetchRecentUITxSummaries(
   api?: string
 ): Promise<TransactionSummaryListResponse> {
   const apiUrl = getApiUrl(chain, api);
-  // stacksAPIFetchJson throws on non-2xx so an SSR error surfaces via page.tsx's catch/logError
-  // instead of seeding the query cache with an error body.
   return await stacksAPIFetchJson<TransactionSummaryListResponse>(
     `${apiUrl}/extended/v3/transactions?limit=${TXS_LIST_SIZE}`,
     {

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,10 +1,10 @@
 import { FeeSection } from '@/app/_components/FeeSection';
 import { MempoolSection } from '@/app/_components/MempoolSection';
 import { NetworkModes } from '@/common/types/network';
+import { TransactionSummaryListResponse } from '@/common/types/tx-v3';
 import { logError } from '@/common/utils/error-utils';
 import { SampleTxsFeeEstimate, getSampleTxsFeeEstimate } from '@/common/utils/fee-utils';
 import { getApiUrl } from '@/common/utils/network-utils';
-import { CompressedTxTableData } from '@/common/utils/transaction-utils';
 import { Flex, Stack } from '@chakra-ui/react';
 
 import { NetworkOverview } from './_components/NetworkOverview/NetworkOverview';
@@ -18,7 +18,7 @@ import {
   UIStackingCycle,
   fetchCurrentStackingCycle,
   fetchRecentBlocks,
-  fetchRecentUITxs,
+  fetchRecentUITxSummaries,
   fetchUIMempoolStats,
 } from './data';
 import { CommonSearchParams } from './transactions/page';
@@ -34,7 +34,7 @@ export default async function HomeRedesign(props: { searchParams: Promise<HomeSe
 
   let recentBlocks: RecentBlocks | undefined;
   let stackingCycle: UIStackingCycle | undefined;
-  let initialTxTableData: CompressedTxTableData | undefined;
+  let initialTxTableData: TransactionSummaryListResponse | undefined;
   let mempoolStats: UIMempoolStats | undefined;
   let feeEstimates: SampleTxsFeeEstimate | undefined;
 
@@ -44,7 +44,7 @@ export default async function HomeRedesign(props: { searchParams: Promise<HomeSe
       : ([
           fetchRecentBlocks(chain, api),
           fetchCurrentStackingCycle(chain, api),
-          fetchRecentUITxs(chain, api),
+          fetchRecentUITxSummaries(chain, api),
           fetchUIMempoolStats(chain, api),
           getSampleTxsFeeEstimate(chain as 'mainnet' | 'testnet', apiUrl),
         ] as const);

--- a/src/common/components/table/UpdateTableBannerRow.tsx
+++ b/src/common/components/table/UpdateTableBannerRow.tsx
@@ -24,6 +24,15 @@ export function UpdateTableBannerRow({ onClick, colSpan, message }: UpdateTableB
         },
       }}
       onClick={onClick}
+      onKeyDown={e => {
+        if (e.key === 'Enter' || e.key === ' ') {
+          e.preventDefault();
+          onClick();
+        }
+      }}
+      role="button"
+      tabIndex={0}
+      aria-label={message}
       cursor="pointer"
       className="group"
     >

--- a/src/common/components/table/table-examples/TxSummaryTable.tsx
+++ b/src/common/components/table/table-examples/TxSummaryTable.tsx
@@ -62,15 +62,21 @@ export function TxSummaryTable({
 
   const [isSubscriptionActive, setIsSubscriptionActive] = useState(false);
   const [newTxsAvailable, setNewTxsAvailable] = useState(false);
+  const newTxsTimer = useRef<ReturnType<typeof setTimeout>>(undefined);
 
   useSubscribeTxs(isSubscriptionActive, () => {
     // Wait 5 seconds to let the API catch up to the websocket before offering a refresh.
-    setTimeout(() => setNewTxsAvailable(true), 5000);
+    if (newTxsTimer.current) return;
+    newTxsTimer.current = setTimeout(() => {
+      setNewTxsAvailable(true);
+      newTxsTimer.current = undefined;
+    }, 5000);
     setIsSubscriptionActive(false);
   });
   useEffect(() => {
     if (!newTxsAvailable) setIsSubscriptionActive(true);
   }, [newTxsAvailable]);
+  useEffect(() => () => clearTimeout(newTxsTimer.current), []);
 
   const rowData: TxSummaryTableData[] = useMemo(
     () =>

--- a/src/common/components/table/table-examples/TxSummaryTable.tsx
+++ b/src/common/components/table/table-examples/TxSummaryTable.tsx
@@ -1,0 +1,121 @@
+'use client';
+
+import { useSubscribeTxs } from '@/app/_components/BlockList/Sockets/useSubscribeTxs';
+import { useGlobalContext } from '@/common/context/useGlobalContext';
+import { THIRTY_SECONDS } from '@/common/queries/query-stale-time';
+import {
+  confirmedTxSummariesQueryKey,
+  useConfirmedTxSummaries,
+} from '@/common/queries/useConfirmedTxSummaries';
+import { TransactionSummary, TransactionSummaryListResponse } from '@/common/types/tx-v3';
+import { validateStacksContractId } from '@/common/utils/utils';
+import { getV3ToAddress } from '@/features/txs-list/utils';
+import { useQueryClient } from '@tanstack/react-query';
+import { ColumnDef } from '@tanstack/react-table';
+import { type JSX, useEffect, useMemo, useRef, useState } from 'react';
+
+import { ScrollIndicator } from '../../ScrollIndicator';
+import { Table } from '../Table';
+import { UpdateTableBannerRow } from '../UpdateTableBannerRow';
+import { TxTableAddressColumnData } from './TxsTable';
+import { TxTableColumns } from './types';
+
+export interface TxSummaryTableData {
+  [TxTableColumns.Transaction]: TransactionSummary;
+  [TxTableColumns.TxId]: string;
+  [TxTableColumns.TxType]: TransactionSummary['type'];
+  [TxTableColumns.From]: TxTableAddressColumnData;
+  [TxTableColumns.To]: TxTableAddressColumnData;
+  [TxTableColumns.BlockTime]: number;
+}
+
+export interface TxSummaryTableProps {
+  initialData: TransactionSummaryListResponse | undefined;
+  pageSize: number;
+  columnDefinitions: ColumnDef<TxSummaryTableData>[];
+  tableContainer?: (table: JSX.Element) => JSX.Element;
+}
+
+export function TxSummaryTable({
+  initialData,
+  pageSize,
+  columnDefinitions,
+  tableContainer,
+}: TxSummaryTableProps) {
+  const queryClient = useQueryClient();
+  const { activeNetwork } = useGlobalContext();
+  const isCacheSetWithInitialData = useRef(false);
+
+  // Seed the query cache with the server-fetched first page so the first client render
+  // matches SSR. See the equivalent note in TxsTable: react-query's initialData prop
+  // misbehaves across hydration, so the cache is set explicitly instead.
+  if (!isCacheSetWithInitialData.current && initialData) {
+    queryClient.setQueryData(
+      confirmedTxSummariesQueryKey(activeNetwork.networkId, pageSize),
+      initialData
+    );
+    isCacheSetWithInitialData.current = true;
+  }
+
+  const { data, refetch, isFetching, isLoading } = useConfirmedTxSummaries(pageSize, {
+    staleTime: THIRTY_SECONDS,
+    gcTime: THIRTY_SECONDS,
+  });
+
+  const [isSubscriptionActive, setIsSubscriptionActive] = useState(false);
+  const [newTxsAvailable, setNewTxsAvailable] = useState(false);
+
+  useSubscribeTxs(isSubscriptionActive, () => {
+    // Wait 5 seconds to let the API catch up to the websocket before offering a refresh.
+    setTimeout(() => setNewTxsAvailable(true), 5000);
+    setIsSubscriptionActive(false);
+  });
+  useEffect(() => {
+    if (!newTxsAvailable) setIsSubscriptionActive(true);
+  }, [newTxsAvailable]);
+
+  const rowData: TxSummaryTableData[] = useMemo(
+    () =>
+      (data?.results ?? []).map(tx => {
+        const to = getV3ToAddress(tx);
+        return {
+          [TxTableColumns.Transaction]: tx,
+          [TxTableColumns.TxId]: tx.tx_id,
+          [TxTableColumns.TxType]: tx.type,
+          [TxTableColumns.From]: {
+            address: tx.sender.address,
+            isContract: validateStacksContractId(tx.sender.address),
+          },
+          [TxTableColumns.To]: {
+            address: to,
+            isContract: validateStacksContractId(to),
+          },
+          [TxTableColumns.BlockTime]: tx.block.time,
+        };
+      }),
+    [data?.results]
+  );
+
+  return (
+    <Table
+      data={rowData}
+      columns={columnDefinitions}
+      tableContainerWrapper={tableContainer ? table => tableContainer(table) : undefined}
+      scrollIndicatorWrapper={table => <ScrollIndicator>{table}</ScrollIndicator>}
+      bannerRow={
+        newTxsAvailable ? (
+          <UpdateTableBannerRow
+            onClick={() => {
+              setNewTxsAvailable(false);
+              refetch();
+            }}
+            colSpan={columnDefinitions.length}
+            message="New transactions have come in. Update list"
+          />
+        ) : null
+      }
+      isLoading={isLoading}
+      isFetching={isFetching}
+    />
+  );
+}

--- a/src/common/components/table/table-examples/TxSummaryTable.tsx
+++ b/src/common/components/table/table-examples/TxSummaryTable.tsx
@@ -46,9 +46,7 @@ export function TxSummaryTable({
   const { activeNetwork } = useGlobalContext();
   const isCacheSetWithInitialData = useRef(false);
 
-  // Seed the query cache with the server-fetched first page so the first client render
-  // matches SSR. See the equivalent note in TxsTable: react-query's initialData prop
-  // misbehaves across hydration, so the cache is set explicitly instead.
+  // react-query's initialData prop misbehaves across hydration, so seed the cache explicitly
   if (!isCacheSetWithInitialData.current && initialData) {
     queryClient.setQueryData(
       confirmedTxSummariesQueryKey(activeNetwork.networkId, pageSize),

--- a/src/common/components/table/table-examples/TxTableCellRenderers.tsx
+++ b/src/common/components/table/table-examples/TxTableCellRenderers.tsx
@@ -1,7 +1,9 @@
 import { TxLink } from '@/common/components/ExplorerLinks';
 import { TransactionStatus as TransactionStatusEnum } from '@/common/constants/constants';
+import { TransactionSummary } from '@/common/types/tx-v3';
 import { getTransactionStatus, getTxTitle } from '@/common/utils/transactions';
 import { truncateHex } from '@/common/utils/utils';
+import { getV3TxStatus, getV3TxTitle } from '@/features/txs-list/utils';
 import { TransactionTypeBadge } from '@/ui/Badge';
 import { Text } from '@/ui/Text';
 import { Tooltip } from '@/ui/Tooltip';
@@ -123,6 +125,18 @@ function getTxStatusBgColor(status: TransactionStatus | MempoolTransactionStatus
   }
 }
 
+function getTxStatusLabel(status: TransactionStatus | MempoolTransactionStatus) {
+  switch (status) {
+    case 'pending':
+      return 'Pending';
+    case 'abort_by_post_condition':
+    case 'abort_by_response':
+      return 'Failed';
+    default:
+      return status;
+  }
+}
+
 export const StatusTag = ({ status }: { status: TransactionStatus | MempoolTransactionStatus }) => {
   return (
     <Flex
@@ -132,6 +146,8 @@ export const StatusTag = ({ status }: { status: TransactionStatus | MempoolTrans
       py={1}
       bg={getTxStatusBgColor(status)}
       borderRadius="redesign.md"
+      role="img"
+      aria-label={`Transaction status: ${getTxStatusLabel(status)}`}
     >
       <Icon h={3} w={3} color={getTxStatusIconColor(status)}>
         {getTxStatusIcon(status)}
@@ -158,6 +174,27 @@ export const TransactionTitleCellRenderer = (tx: Transaction | MempoolTransactio
       <Flex alignItems="center" gap={1.5}>
         {content}
         <StatusTag status={tx.tx_status} />
+      </Flex>
+    );
+  }
+
+  return content;
+};
+
+export const TxSummaryTitleCellRenderer = (tx: TransactionSummary) => {
+  const title = getV3TxTitle(tx);
+  const content = (
+    <TxLink txId={tx.tx_id} variant="tableLink">
+      <EllipsisText textStyle="text-medium-sm">{title}</EllipsisText>
+    </TxLink>
+  );
+
+  // The v3 feed is confirmed-only, so there's no PENDING branch (unlike the v1 renderer above).
+  if (getV3TxStatus(tx.status) === TransactionStatusEnum.FAILED) {
+    return (
+      <Flex alignItems="center" gap={1.5}>
+        {content}
+        <StatusTag status={tx.status} />
       </Flex>
     );
   }

--- a/src/common/queries/useConfirmedTxSummaries.ts
+++ b/src/common/queries/useConfirmedTxSummaries.ts
@@ -19,7 +19,6 @@ export function useConfirmedTxSummaries(
   return useQuery({
     queryKey: confirmedTxSummariesQueryKey(activeNetwork.networkId, limit),
     queryFn: async () =>
-      // v3 only supports limit + cursor here; type/address/sort filters are not available
       await callApiWithErrorHandling(apiClient, '/extended/v3/transactions', {
         params: { query: { limit } },
       }),

--- a/src/common/queries/useConfirmedTxSummaries.ts
+++ b/src/common/queries/useConfirmedTxSummaries.ts
@@ -1,0 +1,29 @@
+import { UseQueryResult, useQuery } from '@tanstack/react-query';
+
+import { callApiWithErrorHandling } from '../../api/callApiWithErrorHandling';
+import { useApiClient } from '../../api/useApiClient';
+import { DEFAULT_LIST_LIMIT } from '../constants/constants';
+import { useGlobalContext } from '../context/useGlobalContext';
+import { TransactionSummaryListResponse } from '../types/tx-v3';
+import { TWO_MINUTES } from './query-stale-time';
+
+export const confirmedTxSummariesQueryKey = (networkId: number | string, limit: number) =>
+  ['confirmedTxSummaries', networkId, limit] as const;
+
+export function useConfirmedTxSummaries(
+  limit = DEFAULT_LIST_LIMIT,
+  options: any = {}
+): UseQueryResult<TransactionSummaryListResponse> {
+  const apiClient = useApiClient();
+  const { activeNetwork } = useGlobalContext();
+  return useQuery({
+    queryKey: confirmedTxSummariesQueryKey(activeNetwork.networkId, limit),
+    queryFn: async () =>
+      // v3 only supports limit + cursor here; type/address/sort filters are not available
+      await callApiWithErrorHandling(apiClient, '/extended/v3/transactions', {
+        params: { query: { limit } },
+      }),
+    staleTime: TWO_MINUTES,
+    ...options,
+  });
+}

--- a/src/common/types/tx-v3.ts
+++ b/src/common/types/tx-v3.ts
@@ -2,4 +2,6 @@ import { OperationResponse } from '@stacks/blockchain-api-client';
 
 export type TransactionSummary = OperationResponse['get_transactions']['results'][number];
 
+export type TransactionSummaryListResponse = OperationResponse['get_transactions'];
+
 export type BlockTransactionSummaryListResponse = OperationResponse['get_block_transactions'];

--- a/src/features/txs-list/__tests__/utils.test.ts
+++ b/src/features/txs-list/__tests__/utils.test.ts
@@ -1,5 +1,9 @@
 import { TransactionStatus } from '../../../common/constants/constants';
-import { getV3TxStatus } from '../utils';
+import { TransactionSummary } from '../../../common/types/tx-v3';
+import { getV3ToAddress, getV3TxStatus, getV3TxTitle } from '../utils';
+
+const summary = (overrides: Record<string, unknown>): TransactionSummary =>
+  ({ block: { height: 1000 }, ...overrides }) as unknown as TransactionSummary;
 
 describe('getV3TxStatus', () => {
   it('maps success to the anchor-block status', () => {
@@ -8,5 +12,63 @@ describe('getV3TxStatus', () => {
 
   it('maps an abort status to failed', () => {
     expect(getV3TxStatus('abort_by_post_condition')).toBe(TransactionStatus.FAILED);
+  });
+});
+
+describe('getV3TxTitle', () => {
+  it('renders the function name for a contract call', () => {
+    expect(
+      getV3TxTitle(summary({ type: 'contract_call', contract_call: { function_name: 'transfer' } }))
+    ).toBe('transfer');
+  });
+
+  it('labels the genesis transfer at block height 1', () => {
+    expect(
+      getV3TxTitle(
+        summary({ type: 'token_transfer', block: { height: 1 }, token_transfer: { amount: '5' } })
+      )
+    ).toBe('Stacks 2.0 genesis transfer');
+  });
+
+  it('formats a token transfer amount', () => {
+    expect(
+      getV3TxTitle(
+        summary({
+          type: 'token_transfer',
+          block: { height: 2 },
+          token_transfer: { amount: '1000000' },
+        })
+      )
+    ).toBe('Send 1.00 STX');
+  });
+
+  it('labels a coinbase with its block height (v3 feed is confirmed-only)', () => {
+    expect(getV3TxTitle(summary({ type: 'coinbase' }))).toBe('Block #1000');
+  });
+});
+
+describe('getV3ToAddress', () => {
+  it('returns the recipient for a token transfer', () => {
+    expect(
+      getV3ToAddress(summary({ type: 'token_transfer', token_transfer: { recipient: 'SP123' } }))
+    ).toBe('SP123');
+  });
+
+  it('returns the contract id for a contract call', () => {
+    expect(
+      getV3ToAddress(summary({ type: 'contract_call', contract_call: { contract_id: 'SP1.abc' } }))
+    ).toBe('SP1.abc');
+  });
+
+  it('returns the contract id for a smart contract deploy', () => {
+    expect(
+      getV3ToAddress(
+        summary({ type: 'smart_contract', smart_contract: { contract_id: 'SP1.abc' } })
+      )
+    ).toBe('SP1.abc');
+  });
+
+  it('returns empty for types without a target', () => {
+    expect(getV3ToAddress(summary({ type: 'coinbase' }))).toBe('');
   });
 });

--- a/src/features/txs-list/utils.ts
+++ b/src/features/txs-list/utils.ts
@@ -3,12 +3,44 @@ import { TransactionType } from '@stacks/stacks-blockchain-api-types';
 import { TransactionStatus } from '../../common/constants/constants';
 import { TxStatus } from '../../common/types/tx';
 import { TransactionSummary } from '../../common/types/tx-v3';
+import { getContractName, microToStacksFormatted } from '../../common/utils/utils';
 
 // v3 list endpoints only return confirmed, canonical txs, so the microblock/non-canonical
 // states that getTransactionStatus handles can't occur here.
 export function getV3TxStatus(status: TransactionSummary['status']): TxStatus {
   if (status === 'success') return TransactionStatus.SUCCESS_ANCHOR_BLOCK;
   return TransactionStatus.FAILED;
+}
+
+export function getV3TxTitle(tx: TransactionSummary): string {
+  switch (tx.type) {
+    case 'smart_contract':
+      return getContractName(tx.smart_contract.contract_id);
+    case 'contract_call':
+      return tx.contract_call.function_name;
+    case 'token_transfer':
+      if (tx.block.height === 1) return 'Stacks 2.0 genesis transfer';
+      return `Send ${microToStacksFormatted(tx.token_transfer.amount)} STX`;
+    case 'coinbase':
+      return `Block #${tx.block.height}`;
+    case 'poison_microblock':
+      return 'Poison microblock transaction';
+    case 'tenure_change':
+      return `Tenure ${tx.tenure_change.cause} (#${tx.block.height})`;
+  }
+}
+
+export function getV3ToAddress(tx: TransactionSummary): string {
+  switch (tx.type) {
+    case 'token_transfer':
+      return tx.token_transfer.recipient;
+    case 'smart_contract':
+      return tx.smart_contract.contract_id;
+    case 'contract_call':
+      return tx.contract_call.contract_id;
+    default:
+      return '';
+  }
 }
 
 export const getTransactionTypeLabel = (value: TransactionType) => {

--- a/src/features/txs-list/utils.ts
+++ b/src/features/txs-list/utils.ts
@@ -27,6 +27,8 @@ export function getV3TxTitle(tx: TransactionSummary): string {
       return 'Poison microblock transaction';
     case 'tenure_change':
       return `Tenure ${tx.tenure_change.cause} (#${tx.block.height})`;
+    default:
+      return (tx as TransactionSummary).tx_id;
   }
 }
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [x] Optimization
- [ ] Documentation Update

## Description
migrate homepage latest transactions to v3 endpoint

## Issue ticket number and link

# Checklist:
- [x] I have performed a self-review of my code.
- [ ] I have tested the change on desktop and mobile.
- [x] I have added thorough tests where applicable.
- [ ] I've added analytics and error logging where applicable.

## Screenshots (if appropriate):

## Marketing Summary
The homepage's Latest Transactions feed now loads from the Stacks API's leaner v3 endpoint for faster, lighter page loads.