### PR TITLE
feat: show contract source code on the address page

### DIFF
--- a/e2e/page-address.spec.ts
+++ b/e2e/page-address.spec.ts
@@ -57,7 +57,6 @@ test.describe('/address page', () => {
   });
 
   test.describe('Source code tab', () => {
-    // Boot contract: deployed by the boot address, guaranteed to exist on mainnet forever
     const contractId = 'SP000000000000000000002Q6VF78.pox-4';
 
     test('renders for a contract principal and is reachable via ?tab=sourceCode', async ({

--- a/e2e/page-address.spec.ts
+++ b/e2e/page-address.spec.ts
@@ -55,4 +55,40 @@ test.describe('/address page', () => {
       await expect(pendingTab).toHaveAttribute('aria-selected', 'true');
     });
   });
+
+  test.describe('Source code tab', () => {
+    // Boot contract: deployed by the boot address, guaranteed to exist on mainnet forever
+    const contractId = 'SP000000000000000000002Q6VF78.pox-4';
+
+    test('renders for a contract principal and is reachable via ?tab=sourceCode', async ({
+      page,
+    }) => {
+      await page.goto(`/address/${contractId}?chain=mainnet&tab=sourceCode`);
+      const sourceTab = page.getByRole('tab', { name: 'Source code' });
+      await expect(sourceTab).toBeVisible();
+      await expect(sourceTab).toHaveAttribute('aria-selected', 'true');
+      await expect(page.getByRole('link', { name: 'View deployment' })).toBeVisible();
+    });
+
+    test('is not rendered for a standard address and ?tab=sourceCode falls back to Overview', async ({
+      page,
+    }) => {
+      const network = Object.keys(addresses)[0];
+      const type = Object.keys((addresses as any)[network])[0];
+      const address = (addresses as any)[network][type][0];
+      await page.goto(`/address/${address}?chain=${network}&tab=sourceCode`);
+      const overviewTab = page.getByRole('tab', { name: 'Overview' });
+      await expect(overviewTab).toHaveAttribute('aria-selected', 'true');
+      await expect(page.getByRole('tab', { name: 'Source code' })).toHaveCount(0);
+    });
+
+    test('shows a not-found message for a shape-valid but nonexistent contract id', async ({
+      page,
+    }) => {
+      await page.goto(
+        `/address/SP000000000000000000002Q6VF78.not-a-real-contract?chain=mainnet&tab=sourceCode`
+      );
+      await expect(page.getByText(/was not found on the current network/)).toBeVisible();
+    });
+  });
 });

--- a/e2e/page-address.spec.ts
+++ b/e2e/page-address.spec.ts
@@ -66,7 +66,9 @@ test.describe('/address page', () => {
       const sourceTab = page.getByRole('tab', { name: 'Source code' });
       await expect(sourceTab).toBeVisible();
       await expect(sourceTab).toHaveAttribute('aria-selected', 'true');
-      await expect(page.getByRole('link', { name: 'View deployment' })).toBeVisible();
+      const viewDeployment = page.getByRole('link', { name: 'View deployment' });
+      await expect(viewDeployment).toBeVisible();
+      await expect(viewDeployment).toHaveAttribute('href', /\/txid\/0x[0-9a-f]{64}/);
     });
 
     test('is not rendered for a standard address and ?tab=sourceCode falls back to Overview', async ({

--- a/src/app/address/[principal]/redesign/AddressTabs.tsx
+++ b/src/app/address/[principal]/redesign/AddressTabs.tsx
@@ -31,7 +31,6 @@ import { NFTTable } from './NFTTable';
 const Source = dynamic(
   () => import('@/app/txid/[txId]/redesign/source/Source').then(module => module.Source),
   {
-    // 500px matches DEFAULT_EDITOR_HEIGHT; importing it from CodeEditor would pull Monaco into this bundle
     loading: () => <Skeleton minHeight="500px" w="full" borderRadius="redesign.xl" />,
     ssr: false,
   }

--- a/src/app/address/[principal]/redesign/AddressTabs.tsx
+++ b/src/app/address/[principal]/redesign/AddressTabs.tsx
@@ -1,3 +1,4 @@
+import { ExplorerErrorBoundary } from '@/app/_components/ErrorBoundary';
 import { ScrollIndicator } from '@/common/components/ScrollIndicator';
 import {
   SectionTabsTrigger,
@@ -15,8 +16,11 @@ import {
 } from '@/common/components/table/table-examples/consts';
 import { useAddressTxs } from '@/common/queries/useAddressConfirmedTxsWithTransfersInfinite';
 import { useNftHoldings } from '@/common/queries/useNftHoldings';
+import { validateStacksContractId } from '@/common/utils/utils';
+import { Skeleton } from '@/components/ui/skeleton';
 import { AddressMempoolTxsList } from '@/features/txs-list/AddressMempoolTxsList';
 import { TabsContent, TabsList, TabsRoot } from '@/ui/Tabs';
+import dynamic from 'next/dynamic';
 import { useSearchParams } from 'next/navigation';
 import { useMemo, useState } from 'react';
 
@@ -24,12 +28,22 @@ import { useAddressIdPageData } from '../AddressIdPageContext';
 import { AddressOverview } from './AddressOverview';
 import { NFTTable } from './NFTTable';
 
+const Source = dynamic(
+  () => import('@/app/txid/[txId]/redesign/source/Source').then(module => module.Source),
+  {
+    // 500px matches DEFAULT_EDITOR_HEIGHT; importing it from CodeEditor would pull Monaco into this bundle
+    loading: () => <Skeleton minHeight="500px" w="full" borderRadius="redesign.xl" />,
+    ssr: false,
+  }
+);
+
 enum AddressIdPageTab {
   Overview = 'overview',
   Transactions = 'transactions',
   Pending = 'pending',
   Tokens = 'tokens',
   Collectibles = 'collectibles',
+  SourceCode = 'sourceCode',
 }
 
 export const AddressTabs = ({ principal }: { principal: string }) => {
@@ -50,13 +64,17 @@ export const AddressTabs = ({ principal }: { principal: string }) => {
   const { data: nftHoldings } = useNftHoldings(principal, 1, 0);
   const totalAddressNonFungibleTokens = nftHoldings?.total ?? 0;
 
+  const isContract = validateStacksContractId(principal);
+
   const searchParams = useSearchParams();
   const tabParam = searchParams.get('tab');
   const initialTab = useMemo(
     () =>
       mapTabParamToEnum<AddressIdPageTab>(
         tabParam,
-        Object.values(AddressIdPageTab) as readonly AddressIdPageTab[],
+        (Object.values(AddressIdPageTab) as readonly AddressIdPageTab[]).filter(
+          tab => isContract || tab !== AddressIdPageTab.SourceCode
+        ),
         AddressIdPageTab.Overview
       ),
     []
@@ -121,6 +139,14 @@ export const AddressTabs = ({ principal }: { principal: string }) => {
               isActive={selectedTab === AddressIdPageTab.Collectibles}
             />
           )}
+          {isContract && (
+            <SectionTabsTrigger
+              key={AddressIdPageTab.SourceCode}
+              label="Source code"
+              value={AddressIdPageTab.SourceCode}
+              isActive={selectedTab === AddressIdPageTab.SourceCode}
+            />
+          )}
         </TabsList>
       </ScrollIndicator>
       <TabsContent key={AddressIdPageTab.Overview} value={AddressIdPageTab.Overview} w="100%">
@@ -145,6 +171,13 @@ export const AddressTabs = ({ principal }: { principal: string }) => {
       <TabsContent key={AddressIdPageTab.Collectibles} value={AddressIdPageTab.Collectibles}>
         <NFTTable />
       </TabsContent>
+      {isContract && (
+        <TabsContent key={AddressIdPageTab.SourceCode} value={AddressIdPageTab.SourceCode} w="100%">
+          <ExplorerErrorBoundary tryAgainButton>
+            <Source contractId={principal} />
+          </ExplorerErrorBoundary>
+        </TabsContent>
+      )}
     </TabsRoot>
   );
 };

--- a/src/app/txid/[txId]/redesign/source/CodeEditor.tsx
+++ b/src/app/txid/[txId]/redesign/source/CodeEditor.tsx
@@ -69,6 +69,8 @@ const CodeEditorBase = forwardRef<any, CodeEditorProps>(({ code, ...editorProps 
           },
           readOnly: true,
           folding: true,
+          // let keyboard users tab out of the read-only editor instead of Monaco swallowing Tab
+          tabFocusMode: true,
           automaticLayout: true,
           scrollBeyondLastLine: false,
           scrollbar: {
@@ -120,6 +122,7 @@ export function withControls(
                 w: 3.5,
               }}
               buttonProps={{
+                'aria-label': 'Copy source code',
                 variant: 'redesignPrimary',
                 p: 1.5,
                 h: BUTTONS_HEIGHT,
@@ -131,7 +134,8 @@ export function withControls(
           {hasExpandButton && (
             <Button
               variant="redesignPrimary"
-              aria-label={'expand source code'}
+              aria-label={isCodeHeightExpanded ? 'collapse source code' : 'expand source code'}
+              aria-expanded={isCodeHeightExpanded}
               onClick={toggleHeight}
               p={1.5}
               h={BUTTONS_HEIGHT}

--- a/src/app/txid/[txId]/redesign/source/CodeEditor.tsx
+++ b/src/app/txid/[txId]/redesign/source/CodeEditor.tsx
@@ -69,7 +69,6 @@ const CodeEditorBase = forwardRef<any, CodeEditorProps>(({ code, ...editorProps 
           },
           readOnly: true,
           folding: true,
-          // let keyboard users tab out of the read-only editor instead of Monaco swallowing Tab
           tabFocusMode: true,
           automaticLayout: true,
           scrollBeyondLastLine: false,

--- a/src/app/txid/[txId]/redesign/source/Source.tsx
+++ b/src/app/txid/[txId]/redesign/source/Source.tsx
@@ -18,10 +18,14 @@ const CodeEditorWithControls = withControls(CodeEditor, true, true);
 export function Source({ contractId }: { contractId: string }) {
   const { data: txContract, isLoading, isError, error, refetch } = useContractById(contractId);
   const sourceCode = txContract?.source_code;
+  const deployTxId = txContract?.tx_id;
   const network = useGlobalContext().activeNetwork;
-  const url = buildUrl(`/txid/${encodeURIComponent(contractId)}`, network);
+  const url = buildUrl(`/txid/${encodeURIComponent(deployTxId || contractId)}`, network);
   const pathname = usePathname();
-  const needLink = !url.includes(pathname);
+  const isDeployTxPage =
+    pathname.startsWith('/txid/') &&
+    (pathname.includes(contractId) || (!!deployTxId && pathname.includes(deployTxId)));
+  const needLink = !isDeployTxPage;
 
   if (isLoading) {
     return <Skeleton minHeight={DEFAULT_EDITOR_HEIGHT} w="full" borderRadius="redesign.xl" />;

--- a/src/app/txid/[txId]/redesign/source/Source.tsx
+++ b/src/app/txid/[txId]/redesign/source/Source.tsx
@@ -1,28 +1,53 @@
 'use client';
 
+import { ApiError } from '@/api/ApiError';
 import { useGlobalContext } from '@/common/context/useGlobalContext';
 import { useContractById } from '@/common/queries/useContractById';
 import { buildUrl } from '@/common/utils/buildUrl';
+import { Skeleton } from '@/components/ui/skeleton';
+import { Button } from '@/ui/Button';
 import { ButtonLink } from '@/ui/ButtonLink';
+import { Text } from '@/ui/Text';
 import { Stack } from '@chakra-ui/react';
 import { usePathname } from 'next/navigation';
 
-import { CodeEditor, withControls } from './CodeEditor';
+import { CodeEditor, DEFAULT_EDITOR_HEIGHT, withControls } from './CodeEditor';
 
 const CodeEditorWithControls = withControls(CodeEditor, true, true);
 
 export function Source({ contractId }: { contractId: string }) {
-  const { data: txContract } = useContractById(contractId);
+  const { data: txContract, isLoading, isError, error, refetch } = useContractById(contractId);
   const sourceCode = txContract?.source_code;
   const network = useGlobalContext().activeNetwork;
   const url = buildUrl(`/txid/${encodeURIComponent(contractId)}`, network);
   const pathname = usePathname();
   const needLink = !url.includes(pathname);
+
+  if (isLoading) {
+    return <Skeleton minHeight={DEFAULT_EDITOR_HEIGHT} w="full" borderRadius="redesign.xl" />;
+  }
+
+  if (isError) {
+    const isNotFound = error instanceof ApiError && error.status === 404;
+    return (
+      <Stack gap={3} alignItems="flex-start">
+        <Text fontSize="sm">
+          {isNotFound
+            ? 'This contract was not found on the current network. It may not be deployed yet.'
+            : 'Failed to load the contract source code.'}
+        </Text>
+        <Button variant="redesignPrimary" onClick={() => refetch()}>
+          Try again
+        </Button>
+      </Stack>
+    );
+  }
+
   return (
     <Stack gap={3}>
       {needLink && (
         <ButtonLink href={url} buttonLinkSize="small" aria-label="View deployment">
-          View deployment{' '}
+          View deployment
         </ButtonLink>
       )}
       <CodeEditorWithControls code={sourceCode || ''} />

--- a/src/common/queries/useContractById.ts
+++ b/src/common/queries/useContractById.ts
@@ -8,7 +8,6 @@ import {
 } from '@tanstack/react-query';
 
 import { callApiWithErrorHandling } from '../../api/callApiWithErrorHandling';
-import { getErrorMessage } from '../../api/getErrorMessage';
 import { useApiClient } from '../../api/useApiClient';
 import { ContractWithParsedAbi } from '../types/contract';
 
@@ -21,12 +20,13 @@ export function useContractById(
     queryKey: ['contractById', contractId],
     queryFn: async () => {
       if (!contractId) return undefined;
-      const { data: contract, error } = await apiClient.GET('/extended/v1/contract/{contract_id}', {
-        params: { path: { contract_id: contractId } },
-      });
-      if (error) {
-        throw new Error(getErrorMessage(error));
-      }
+      const contract = await callApiWithErrorHandling(
+        apiClient,
+        '/extended/v1/contract/{contract_id}',
+        {
+          params: { path: { contract_id: contractId } },
+        }
+      );
       return {
         ...contract,
         abi: contract.abi ? JSON.parse(contract.abi) : undefined,


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
show contract source code on the address page

## Issue ticket number and link

# Checklist:
- [x] I have performed a self-review of my code.
- [ ] I have tested the change on desktop and mobile.
- [x] I have added thorough tests where applicable.
- [x] I've added analytics and error logging where applicable.

## Screenshots (if appropriate):

## Marketing Summary
Smart contract pages just got more useful: you can now read a contract's source code directly on its address page, instead of digging through the deploy transaction. Open any contract address and hit the new "Source code" tab.
