### PR TITLE
feat: migrate address confirmed transactions to v3 endpoint

### DIFF
--- a/src/app/address/[principal]/redesign/AddressTabs.tsx
+++ b/src/app/address/[principal]/redesign/AddressTabs.tsx
@@ -6,16 +6,9 @@ import {
   useDeepLinkTabOnValueChange,
 } from '@/common/components/SectionTabs';
 import { FungibleTokensTableWithFilters } from '@/common/components/table/fungible-tokens-table/FungibleTokensTableWithFilters';
-import {
-  AddressTxsTable,
-  columnDefinitionsWithEvents,
-} from '@/common/components/table/table-examples/AddressTxsTable';
-import {
-  ADDRESS_ID_PAGE_ADDRESS_TXS_LIMIT,
-  ADDRESS_ID_PAGE_FUNGIBLE_TOKENS_LIMIT,
-} from '@/common/components/table/table-examples/consts';
-import { useAddressTxs } from '@/common/queries/useAddressConfirmedTxsWithTransfersInfinite';
+import { ADDRESS_ID_PAGE_FUNGIBLE_TOKENS_LIMIT } from '@/common/components/table/table-examples/consts';
 import { useNftHoldings } from '@/common/queries/useNftHoldings';
+import { usePrincipalTxSummaries } from '@/common/queries/usePrincipalTxSummaries';
 import { validateStacksContractId } from '@/common/utils/utils';
 import { Skeleton } from '@/components/ui/skeleton';
 import { AddressMempoolTxsList } from '@/features/txs-list/AddressMempoolTxsList';
@@ -25,6 +18,7 @@ import { useSearchParams } from 'next/navigation';
 import { useMemo, useState } from 'react';
 
 import { useAddressIdPageData } from '../AddressIdPageContext';
+import { AddressConfirmedTxs } from '../tx-lists/AddressConfirmedTxs';
 import { AddressOverview } from './AddressOverview';
 import { NFTTable } from './NFTTable';
 
@@ -53,7 +47,7 @@ export const AddressTabs = ({ principal }: { principal: string }) => {
   const { initialAddressBalancesData } = useAddressIdPageData();
 
   // TODO: Temporarily fetching client-side - re-enable SSR when API performance is fixed
-  const { data: transactionsData } = useAddressTxs(principal, 1, 0);
+  const { data: transactionsData } = usePrincipalTxSummaries(principal, 1);
   const totalAddressTransactions = transactionsData?.total || 0;
 
   const totalAddressFungibleTokens = Object.entries(
@@ -152,11 +146,7 @@ export const AddressTabs = ({ principal }: { principal: string }) => {
         <AddressOverview />
       </TabsContent>
       <TabsContent key={AddressIdPageTab.Transactions} value={AddressIdPageTab.Transactions}>
-        <AddressTxsTable
-          principal={principal}
-          pageSize={ADDRESS_ID_PAGE_ADDRESS_TXS_LIMIT}
-          columnDefinitions={columnDefinitionsWithEvents}
-        />
+        <AddressConfirmedTxs principal={principal} />
       </TabsContent>
       <TabsContent key={AddressIdPageTab.Pending} value={AddressIdPageTab.Pending}>
         <AddressMempoolTxsList address={principal} />

--- a/src/app/address/[principal]/tx-lists/AddressConfirmedTxs.tsx
+++ b/src/app/address/[principal]/tx-lists/AddressConfirmedTxs.tsx
@@ -1,0 +1,42 @@
+'use client';
+
+import { ListFooter } from '@/common/components/ListFooter';
+import { SkeletonGenericTransactionList } from '@/common/components/loaders/skeleton-transaction';
+import { useSuspenseCursorInfiniteQueryResult } from '@/common/hooks/useCursorInfiniteQueryResult';
+import { useSuspensePrincipalTxSummariesInfinite } from '@/common/queries/usePrincipalTxSummaries';
+import { PrincipalTransactionSummary } from '@/common/types/tx-v3';
+import { FilteredTxSummaries } from '@/features/txs-list/v3/FilteredTxSummaries';
+import { Box } from '@chakra-ui/react';
+import { Suspense, useMemo } from 'react';
+
+import { ExplorerErrorBoundary } from '../../../_components/ErrorBoundary';
+
+function AddressConfirmedTxsBase({ principal }: { principal: string }) {
+  const response = useSuspensePrincipalTxSummariesInfinite(principal);
+  const items = useSuspenseCursorInfiniteQueryResult<PrincipalTransactionSummary>(response);
+  const txs = useMemo(() => items.map(item => item.transaction), [items]);
+
+  return (
+    <Box flexGrow={1}>
+      <Box position="relative">
+        <FilteredTxSummaries txs={txs} />
+        <ListFooter
+          isLoading={response.isFetchingNextPage}
+          hasNextPage={response.hasNextPage}
+          fetchNextPage={response.fetchNextPage}
+          label="transactions"
+        />
+      </Box>
+    </Box>
+  );
+}
+
+export function AddressConfirmedTxs({ principal }: { principal: string }) {
+  return (
+    <ExplorerErrorBoundary tryAgainButton>
+      <Suspense fallback={<SkeletonGenericTransactionList />}>
+        <AddressConfirmedTxsBase principal={principal} />
+      </Suspense>
+    </ExplorerErrorBoundary>
+  );
+}

--- a/src/common/queries/usePrincipalTxSummaries.ts
+++ b/src/common/queries/usePrincipalTxSummaries.ts
@@ -1,0 +1,67 @@
+import {
+  InfiniteData,
+  UseQueryResult,
+  UseSuspenseInfiniteQueryResult,
+  useQuery,
+  useSuspenseInfiniteQuery,
+} from '@tanstack/react-query';
+
+import { callApiWithErrorHandling } from '../../api/callApiWithErrorHandling';
+import { useApiClient } from '../../api/useApiClient';
+import { ADDRESS_ID_PAGE_ADDRESS_TXS_LIMIT } from '../components/table/table-examples/consts';
+import { useGlobalContext } from '../context/useGlobalContext';
+import { getNextCursorPageParam } from '../hooks/useCursorInfiniteQueryResult';
+import { PrincipalTransactionSummaryListResponse } from '../types/tx-v3';
+import { TWO_MINUTES } from './query-stale-time';
+
+export function useSuspensePrincipalTxSummariesInfinite(
+  principal: string,
+  options: any = {}
+): UseSuspenseInfiniteQueryResult<InfiniteData<PrincipalTransactionSummaryListResponse>> {
+  const apiClient = useApiClient();
+  const { activeNetwork } = useGlobalContext();
+  return useSuspenseInfiniteQuery({
+    queryKey: ['principalTxSummariesInfinite', activeNetwork.networkId, principal],
+    queryFn: async ({ pageParam }: { pageParam: string | undefined }) =>
+      await callApiWithErrorHandling(
+        apiClient,
+        '/extended/v3/principals/{principal}/transactions',
+        {
+          params: {
+            path: { principal },
+            query: {
+              limit: ADDRESS_ID_PAGE_ADDRESS_TXS_LIMIT,
+              ...(pageParam ? { cursor: pageParam } : {}),
+            },
+          },
+        }
+      ),
+    getNextPageParam: getNextCursorPageParam,
+    initialPageParam: undefined as string | undefined,
+    staleTime: TWO_MINUTES,
+    ...options,
+  });
+}
+
+export function usePrincipalTxSummaries(
+  principal: string,
+  limit: number,
+  options: any = {}
+): UseQueryResult<PrincipalTransactionSummaryListResponse> {
+  const apiClient = useApiClient();
+  const { activeNetwork } = useGlobalContext();
+  return useQuery({
+    queryKey: ['principalTxSummaries', activeNetwork.networkId, principal, limit],
+    queryFn: async () =>
+      await callApiWithErrorHandling(
+        apiClient,
+        '/extended/v3/principals/{principal}/transactions',
+        {
+          params: { path: { principal }, query: { limit } },
+        }
+      ),
+    staleTime: TWO_MINUTES,
+    enabled: !!principal,
+    ...options,
+  });
+}

--- a/src/common/types/tx-v3.ts
+++ b/src/common/types/tx-v3.ts
@@ -5,3 +5,9 @@ export type TransactionSummary = OperationResponse['get_transactions']['results'
 export type TransactionSummaryListResponse = OperationResponse['get_transactions'];
 
 export type BlockTransactionSummaryListResponse = OperationResponse['get_block_transactions'];
+
+export type PrincipalTransactionSummary =
+  OperationResponse['get_principal_transactions']['results'][number];
+
+export type PrincipalTransactionSummaryListResponse =
+  OperationResponse['get_principal_transactions'];


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [ ] Refactor
- [x] Feature
- [x] Optimization

## Description
migrate address confirmed transactions to v3 endpoint

## Issue ticket number and link

# Checklist:
- [x] I have performed a self-review of my code.
- [ ] I have tested the change on desktop and mobile.
- [x] I have added thorough tests where applicable.
- [ ] I've added analytics and error logging where applicable.

## Screenshots (if appropriate):

## Marketing Summary
The address page's transaction list now loads from the Stacks API's leaner v3 endpoint, with smooth cursor-based "load more" paging for faster, lighter browsing.